### PR TITLE
Hotfix : 機能していないハイパーリンクの修正+翻訳の微修正

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -2,24 +2,24 @@
 [appendix]
 == 専門用語/Terminology
 === インプレイとアウトオブプレイ/Ball In And Out Of Play
-試合が停止されると、ボールは次のプレイに移行するまではアウトオブプレイとみなされる。 +
-When the match is <<Stopping The Game, stopped>>, the ball is considered *out of play* until it has been brought into play.
+試合が<<試合の停止/Stopping The Game, 停止>>されると、ボールは次のプレイに移行するまではアウトオブプレイとみなされる。 +
+When the match is <<試合の停止/Stopping The Game, stopped>>, the ball is considered *out of play* until it has been brought into play.
 
-試合が再開されると、ボールは次の停止が発生するまではインプレイとみなされる。フォーススタートが発行される、もしくはキックオフ、直接フリーキック、間接フリーキック、ペナルティキックによってボールが0.05m以上移動した時に試合が再開される。 +
-When the match is <<Resuming The Game, resumed>>, the ball is considered *in play* until the next stoppage occurs. The match is resumed when <<Force Start, force start>> has been issued or the ball moved at least 0.05 meters following a <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free kick>> or <<Penalty Kick, penalty kick>>.
+試合が<<試合の再開/Resuming The Game, 再開>>されると、ボールは次の停止が発生するまではインプレイとみなされる。<<フォーススタート/Force Start, フォーススタート>>が発行される、もしくは<<キックオフ/Kick-Off, キックオフ>>、<<直接フリーキック/Direct Free Kick, 直接フリーキック>>、<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>、<<ペナルティーキック/Penalty Kick, ペナルティキック>>によってボールが0.05m以上移動した時に試合が再開される。 +
+When the match is <<試合の再開/Resuming The Game, resumed>>, the ball is considered *in play* until the next stoppage occurs. The match is resumed when <<フォーススタート/Force Start, force start>> has been issued or the ball moved at least 0.05 meters following a <<キックオフ/Kick-Off, kick-off>>, <<直接フリーキック/Direct Free Kick, direct free kick>>, <<間接フリーキック/Indirect Free Kick, indirect free kick>> or <<ペナルティーキック/Penalty Kick, penalty kick>>.
 
-NOTE: 0.05メートルの距離の理論的根拠についてはダブルタッチを参照すること +
-see <<Double Touch, double touch>> for the rationale of the 0.05 meter distance
+NOTE: 0.05メートルの距離の理論的根拠については「<<ダブルタッチ/Double Touch, ダブルタッチ>>」を参照すること +
+see <<ダブルタッチ/Double Touch, double touch>> for the rationale of the 0.05 meter distance
 
 
 === ボールの操作/Ball Manipulation
-シュートとドリブルはボールの操作とみなされ、ボールが機体で跳ね返った場合は操作とはみなさない。 +
-Shooting and <<Dribbling Device, dribbling>> is considered as manipulating the ball, the ball accidentally bouncing off the hull is not.
+シュートと<<ドリブルデバイス/Dribbling Device, ドリブル>>はボールの操作とみなされ、ボールが機体で跳ね返った場合は操作とはみなさない。 +
+Shooting and <<ドリブルデバイス/Dribbling Device, dribbling>> is considered as manipulating the ball, the ball accidentally bouncing off the hull is not.
 
 
 [appendix]
 == ゲームイベント表/Game Event Table
-ゲームイベント表は、各ゲームイベントとその結果をまとめたものである。また、Automatic Refereeの実装が処理できなければならないものを表記する。 +
+ゲームイベント表は、各ゲームイベントとその結果をまとめたものである。また、<<Automatic Referee>>の実装が処理できなければならないものを表記する。 +
 The game event table is a compilation of the different game events and their consequences. It also lists what all <<Automatic Referee>> implementations must be capable of handling.
 
 NOTE: この表にまとめられた情報は不完全なものである。すべての定義を確認するには、対応した各章を読むこと。 +
@@ -29,51 +29,162 @@ Chapter <<ロボット/Robots>>:
 |===
 | イベント/Event | 適用範囲/Applicability | 実行されるコマンド/Command | AutoRef
 
-| <<ロボットの台数/Number Of Robots>> exceeded | 常時/always | <<停止/Stop>> | icon:check[role="green"]
+| <<ロボットの台数/Number Of Robots,ロボットの台数>>超過 +
+<<ロボットの台数/Number Of Robots, Number Of Robots>> exceeded | 常時/always | <<停止/Stop>> | icon:check[role="green"]
 |===
 
 Chapter <<レフェリーコマンド/Referee Commands>>:
 |===
 | イベント/Event | 適用範囲/Applicability | 実行されるコマンド/Command | AutoRef
 
-| <<キックオフ/Kick-Off>> prepared | during <<キックオフ/Kick-Off>> | <<Normal Start>> | icon:check[role="green"]
-| No Progress | <<Ball In And Out Of Play, ball in play>> | <<停止/Stop>>, then <<フォーススタート/Force Start>> | icon:check[role="green"]
-| <<ペナルティーキック/Penalty Kick>> prepared | during <<ペナルティーキック/Penalty Kick>> | <<Normal Start>> | icon:check[role="green"]
-| Multiple <<Yellow Card, Yellow Cards>> | <<Ball In And Out Of Play, ball out of play>> | <<ペナルティーキック/Penalty Kick>> | icon:times[role="red"] (ゲームコントローラーにより処理される +
+| <<キックオフ/Kick-Off, キックオフ>>準備完了 +
+<<キックオフ/Kick-Off, Kick-Off>> prepared 
+| <<キックオフ/Kick-Off, キックオフ>>発効中 +
+during <<キックオフ/Kick-Off, Kick-Off>> 
+| <<ノーマルスタート/Normal Start, ノーマルスタート>> +
+<<ノーマルスタート/Normal Start, Normal Start>> 
+| icon:check[role="green"]
+| 何も起きていない +
+No Progress 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<フォーススタート/FOrce Start, フォーススタート>> +
+<<停止/Stop, Stop>>, then <<フォーススタート/Force Start, Force>> 
+| icon:check[role="green"]
+| <<ペナルティーキック/Penalty Kick, ペナルティーキック>>準備完了 +
+<<ペナルティーキック/Penalty Kick, Penalty Kick>> prepared 
+| <<ペナルティキック/Penalty Kick, ペナルティーキック>>発効中 +
+during <<ペナルティーキック/Penalty Kick, Penalty Kick>> 
+| <<ノーマルスタート/Normal Start, ノーマルスタート>> +
+<<ノーマルスタート/Normal Start, Normal Start>> 
+| icon:check[role="green"]
+| 複数枚の<<イエローカード/Yellow Card, イエローカード>> +
+Multiple <<イエローカード/Yellow Card, Yellow Cards>> 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>中  +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball out of play>> 
+| <<ペナルティーキック/Penalty Kick, ペナルティーキック>> +
+<<ペナルティーキック/Penalty Kick, Penalty Kick>> 
+| icon:times[role="red"] (ゲームコントローラーにより処理される +
 handled by the game controller)
-| <<ボール配置/Ball Placement>> failed by team in favor | during <<ボール配置/Ball Placement>> | <<ストップ/Stop>>, then <<間接フリーキック/Direct Free Kick>> (div A) / previous command (div B) | icon:check[role="green"]
-| <<ボール配置/Ball Placement>> failed by opponent | during <<ボール配置/Ball Placement>> | <<Stop>> | icon:check[role="green"]
-| <<ボール配置/Ball Placement>> successful | during <<ボール配置/Ball Placement>> | continue | icon:check[role="green"]
+| 次にインプレイにする権利を持つチームによる<<ボール配置/Ball Placement, ボール配置>>の失敗 +
+ <<ボール配置/Ball Placement, Ball Placement>> failed by team in favor 
+| <<ボール配置/Ball Placement, ボール配置>>中 +
+during <<ボール配置/Ball Placement, Ball Placement>>  
+| <<停止/Stop, ストップ>>、次いで<<間接フリーキック/Direct Free Kick, 間接フリーキック>>(ディヴィジョンA) / 前回のコマンド(B) +
+<<停止/Stop, Stop>>, then <<間接フリーキック/Indirect Free Kick, Indirect Free Kick>> (div A) / previous command (div B) 
+| icon:check[role="green"]
+| 相手による<<ボール配置/Ball Placement, ボール配置>>の失敗 +
+<<ボール配置/Balll Placement, Ball Placement>> failed by opponent 
+| <<ボール配置/Ball Placement, ボール配置>>中 +
+during <<ボール配置/Ball Placement, Ball Placement>> | <<停止/Stop>> 
+| icon:check[role="green"]
+| <<ボール配置/Ball Placement,ボール配置>>成功 +
+<<ボール配置/Ball Placement, Ball Placement>> successful 
+| <<ボール配置/Ball Placement, ボール配置>>中 +
+during <<ボール配置/Ball Placement, Ball Placement>> 
+| 続行/continue 
+| icon:check[role="green"]
 |===
 
-Chapter <<Ball Leaves The Field>>:
+Chapter <<フィールド外に出るボール/Ball Leaves The Field>>:
 |===
 | イベント/Event | 適用範囲/Applicability | 実行されるコマンド/Command | AutoRef
 
-| <<スローイン/Throw-In>> | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<間接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<ゴールキック/Goal Kick>> | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<コーナーキック/Corner Kick>> | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>> | icon:check[role="green"]
+| <<スローイン/Throw-In, スローイン>> +
+<<スローイン/Throw-In, Throw-In>> 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<間接フリーキック/Direct Free Kick, 間接フリーキック>> +
+<<停止/Stop, Stop>>, then <<間接フリーキック/Indirect Free Kick, Indirect Free Kick>> 
+| icon:check[role="green"]
+| <<ゴールキック/Goal Kick, ゴールキック>> +
+<<ゴールキック/Goal Kick, Goal Kick>>
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>> 
+| icon:check[role="green"]
+| <<コーナーキック/Corner Kick, コーナーキック>> +
+<<コーナーキック/Corner Kick, Corner Kick>> 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>> 
+| icon:check[role="green"]
 |===
 
 Chapter <<ゴールの得点方法/Scoring Goals>>:
 |===
 | イベント/Event | 適用範囲/Applicability | 実行されるコマンド/Command | AutoRef
 
-| Goal | <<Ball In And Out Of Play, ball in play>> | <<停止/Stop>>, then <<キックオフ/Kick-Off>> | (icon:check[role="green"]) footnote:[game controller operatorが試合を続行する/the game controller operator has to continue the game]
-| Invalid Goal | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>> | icon:check[role="green"]
+| ゴール +
+Goal 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<キックオフ/Kick-Off, キックオフ>> +
+<<停止/Stop, Stop>>, then <<キックオフ/Kick-Off, Kick-Off>> 
+| (icon:check[role="green"]) footnote:[game controller operatorが試合を続行する/the game controller operator has to continue the game]
+| 無効なゴール +
+Invalid Goal 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>> 
+| icon:check[role="green"]
 |===
 
-Chapter <<反則/Offenses>>, section <<軽微な反則/Minor Offenses>>:
+Chapter <<反則/Offenses>>, section <<軽微な違反/Minor Offenses>>:
 |===
 | イベント/Event | 適用範囲/Applicability | 実行されるコマンド/Command | AutoRef
 
-| <<Aimless Kick [small]#(_division B only_)#, Aimless Kick>> | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<間接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<進行の欠落/Lack Of Progress>> | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<間接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<ダブルタッチ/Double Touch>> | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<間接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<間接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<Attacker Touches Robot In Opponent Defense Area>> skipped | <<Ball In And Out Of Play, ball in play>> | no command | icon:check[role="green"] (<<Advantage Rule>>)
-| <<ドリブルの超過/Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<間接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<Ball Speed>> | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<間接フリーキック/Direct Free Kick>> | icon:check[role="green"]
+| <<エイムレスキック/Aimless Kick [small]#(_division B only_)#, エイムレスキック>> +
+<<エイムレスキック/Aimless Kick [small]#(_division B only_)#, Aimless Kick>> 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<間接フリーキック/Direct Free Kick, 間接フリーキック>> +
+<<停止/Stop, Stop>>, then <<間接フリーキック/Indirect Free Kick, Indirect Free Kick>> 
+| icon:check[role="green"]
+| <<進行の欠落/Lack Of Progress, 進行の欠落>> +
+<<進行の欠落/Lack Of Progress, Lack Of Progress>> 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<間接フリーキック/Direct Free Kick, 間接フリーキック>> +
+<<停止/Stop, Stop>>, then <<間接フリーキック/Indirect Free Kick, Indirect Free Kick>> 
+| icon:check[role="green"]
+| <<ダブルタッチ/Double Touch, ダブルタッチ>> +
+<<ダブルタッチ/Double Touch, Double Touch>> 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<間接フリーキック/Direct Free Kick, 間接フリーキック>> +
+<<停止/Stop, Stop>>, then <<間接フリーキック/Indirect Free Kick, Indirect Free Kick>> 
+| icon:check[role="green"]
+| <<ディフェンスエリアにあるアタッカー/Attacker In Defense Area, ディフェンスエリアにあるアタッカー>> +
+ <<ディフェンスエリアにあるアタッカー/Attacker In Defense Area, Attacker In Defense Area>>
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<間接フリーキック/Direct Free Kick, 間接フリーキック>> +
+<<停止/Stop, Stop>>, then <<間接フリーキック/Indirect Free Kick, Indirect Free Kick>> 
+| icon:check[role="green"]
+| 「<<相手ディフェンスエリア内におけるアタッカーロボットの相手ロボットへの接触/Attacker Touches Robot In Opponent Defense Area, 相手ディフェンスエリア内におけるアタッカーロボットの相手ロボットへの接触>>」のスキップ +
+<<相手ディフェンスエリア内におけるアタッカーロボットの相手ロボットへの接触/Attacker Touches Robot In Opponent Defense Area, Attacker Touches Robot In Opponent Defense Area>> skipped 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| no command 
+| icon:check[role="green"] (<<Advantage Rule>>)
+| <<ドリブルの超過/Excessive Dribbling, ドリブルの超過>> +
+<<ドリブルの超過/Excessive Dribbling, Excessive Dribbling>> 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<間接フリーキック/Direct Free Kick, 間接フリーキック>> +
+<<停止/Stop, Stop>>, then <<間接フリーキック/Indirect Free Kick, Indirect Free Kick>> 
+| icon:check[role="green"]
+| <<ボール速度/Ball Speed, ボール速度>> +
+<<ボール速度/Ball Speed, Ball Speed>> 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<間接フリーキック/Direct Free Kick, 間接フリーキック>> +
+<<停止/Stop, Stop>>, then <<間接フリーキック/Indirect Free Kick, Indirect Free Kick>> 
+| icon:check[role="green"]
 |===
 
 
@@ -81,21 +192,85 @@ Chapter <<反則/Offenses>>, section <<ファウル/Fouls>>:
 |===
 | イベント/Event | 適用範囲/Applicability | 実行されるコマンド/Command | AutoRef
 
-| Multiple <<ファウル/Fouls>> | <<Ball In And Out Of Play, ball out of play>> | <<イエローカード/Yellow Card>> | icon:times[role="red"] (ゲームコントローラーにより処理される +
+| 複数回の<<ファウル/Fouls, ファウル>> +
+Multiple <<ファウル/Fouls, Fouls>> 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>中  +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball out of play>> 
+| <<イエローカード/Yellow Card>> 
+| icon:times[role="red"] (ゲームコントローラーにより処理される +
 handled by the game controller)
-| <<Attacker Touches Robot In Opponent Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<停止/Stop>>, then <<間接フリーキック/Indirect Free Kick>> | icon:check[role="green"]
-| <<Robot Too Close To Opponent Defense Area>> | <<Ball In And Out Of Play, ball out of play>> | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<ボール配置に干渉する/Ball Placement Interference>> | during <<ボール配置/Ball Placement>> | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<衝突/Crashing>> | always | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<衝突/Crashing>> skipped | always | no command | icon:check[role="green"] (<<Advantage Rule>>)
-| <<衝突/Crashing>> draw | always | no command | icon:check[role="green"]
-| <<Pushing>> | always | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>> | icon:times[role="red"]
-| <<ボールの保持/Ball Holding>> | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<転倒や部品の脱落/Tipping Over Or Dropping Parts>> | always | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>> | icon:times[role="red"]
-| <<Robot Stop Speed>> | during <<Stop>> | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<Defender Too Close To Ball>> | <<Ball In And Out Of Play, ball out of play>> | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>> | icon:check[role="green"]
-| <<マルチプルディフェンス/Multiple Defenders>> partially | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<直接フリーキック/Direct Free Kick>>, <<Yellow Card>> | icon:check[role="green"]
-| <<マルチプルディフェンス/Multiple Defenders>> entirely | <<Ball In And Out Of Play, ball in play>> | <<ストップ/Stop>>, then <<ペナルティーキック/Penalty Kick>> | icon:check[role="green"]
+| <<相手ディフェンスエリア内におけるアタッカーロボットの相手ロボットへの接触/Attacker Touches Robot In Opponent Defense Area, 相手ディフェンスエリア内におけるアタッカーロボットの相手ロボットへの接触>> +
+ <<相手ディフェンスエリア内におけるアタッカーロボットの相手ロボットへの接触/Attacker Touches Robot In Opponent Defense Area, Attacker Touches Robot In Opponent Defense Area>>
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<間接フリーキック/Indirect Free Kick, 間接フリーキック>> +
+<<停止/Stop, Stop>>, then <<間接フリーキック/Indirect Free Kick, Indirect Free Kick>> 
+| icon:check[role="green"]
+| <<ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area, ロボットの相手ディフェンスエリアへの極端な接近>> +
+<<ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area, Robot Too Close To Opponent Defense Area>>  
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>中  +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball out of play>> 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>> 
+| icon:check[role="green"]
+| <<ボール配置への干渉/Ball Placement Interference, ボール配置への干渉>> +
+<<ボール配置への干渉/Ball Placement Interference, Ball Placement Interference>> 
+| <<ボール配置/Ball Placement, ボール配置>>中 +
+during <<ボール配置/Ball Placement, Ball Placement>> 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>> 
+| icon:check[role="green"]
+| <<衝突/Crashing>> | 常時/always 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>> 
+| icon:check[role="green"]
+| <<衝突/Crashing, 衝突の反則>>のスキップ +
+<<衝突/Crashing, Crashing>> skipped | 常時/always | no command 
+| icon:check[role="green"] (<<アドバンテージルール/Advantage Rule>>)
+| 同等な勢いでの<<衝突/Crashing, 相互衝突>> +
+<<衝突/Crashing, Crashing>> draw | 常時/always | no command 
+| icon:check[role="green"]
+| <<プッシング/Pushing>> | 常時/always 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>> 
+| icon:times[role="red"]
+| <<ボールの保持/Ball Holding>> 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>> 
+| icon:check[role="green"]
+| <<転倒や部品の脱落/Tipping Over Or Dropping Parts>> | 常時/always 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>> 
+| icon:times[role="red"]
+| <<ストップ中のロボットの速度/Robot Stop Speed, ストップ中のロボットの速度>> +
+<<ストップ中のロボットの速度/Robot Stop Speed, Robot Stop Speed>>
+| <<停止/Stop, ストップ>>中 +
+during <<停止/Stop, Stop>> 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>> 
+| icon:check[role="green"]
+| <<ディフェンダーのボールへの極端な接近/Defender Too Close To Ball>> 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>中  +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball out of play>> 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>> 
+| icon:check[role="green"]
+| <<マルチプルディフェンス/Multiple Defenders, マルチプルディフェンス>> (一部が侵入している場合) +
+<<マルチプルディフェンス/Multiple Defenders, Multiple Defenders>> partially 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<直接フリーキック/Direct Free Kick, 直接フリーキック>>、<<イエローカード/Yellow Card, イエローカード>> +
+<<停止/Stop, Stop>>, then <<直接フリーキック/Direct Free Kick, Direct Free Kick>>, <<イエローカード/Yellow Card, Yellow Card>> 
+| icon:check[role="green"]
+| <<マルチプルディフェンス/Multiple Defenders, マルチプルディフェンス>> (完全に侵入している場合) +
+<<マルチプルディフェンス/Multiple Defenders, Multiple Defenders>> entirely 
+| <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
+| <<停止/Stop, ストップ>>、次いで<<ペナルティーキック/Penalty Kick, ペナルティーキック>> +
+<<停止/Stop, Stop>>, then <<ペナルティーキック/Penalty Kick, Penalty Kick>> 
+| icon:check[role="green"]
 |===
 
 Chapter <<反則/Offenses>>, section <<非スポーツマン行為/Unsporting Behavior>>:
@@ -103,29 +278,35 @@ Chapter <<反則/Offenses>>, section <<非スポーツマン行為/Unsporting Be
 |===
 | イベント/Event | 適用範囲/Applicability | 実行されるコマンド/Command | AutoRef
 
-| Unsporting Behavior | always | <<停止/Stop>>, then <<イエローカード/Yellow Card>>, <<Red Card>>, <<ペナルティーキック/Penalty Kick>>, <<強制的な試合放棄/Forced Forfeit>> or <<失格/Disqualification>> | icon:times[role="red"]
+| 非スポーツマン行為 +
+Unsporting Behavior | 常時/always 
+| <<停止/Stop, ストップ>>、次いで<<イエローカード/Yellow Card, イエロー>>もしくは<<レッドカード/Red Card,レッドカード>>、ないしは<<ペナルティーキック/Penalty Kick, ペナルティーキック>>、<<強制的な試合放棄/Forced Forfeit, 強制的な試合放棄>>、<<失格/Disqualification, 失格>>のいずれか +
+<<停止/Stop, Stop>>, then <<イエローカード/Yellow Card, Yellow Card>>, <<レッドカード/Red Card, Red Card>>, <<ペナルティーキック/Penalty Kick, Penalty Kick>>, <<強制的な試合放棄/Forced Forfeit, Forced Forfeit>> or <<失格/Disqualification, Disqualification>> | icon:times[role="red"]
 |===
 
 Chapter <<ロボットの交代/Robot Substitution>>:
 |===
 | イベント/Event | 適用範囲/Applicability | 実行されるコマンド/Command | AutoRef
 
-| <<ロボットの交代/Robot Substitution>> Intent | always | <<ハルト/Halt>> (after next stoppage), then <<停止/Stop>> | icon:times[role="red"]
+| <<ロボットの交代/Robot Substitution, ロボットの交代>>意思の表明 +
+<<ロボットの交代/Robot Substitution, Robot Substitution>> Intent | 常時/always 
+| 次のストップで<<ハルト/Halt, ハルト>>、次いで<<停止/Stop, ストップ>> +
+<<ハルト/Halt, Halt>> (after next stoppage), then <<停止/Stop, Stop>> | icon:times[role="red"]
 |===
 
 [appendix]
 == ディヴィジョンごとの違い/Differences Between Divisions
 
-これは、ディヴィジョンAとディヴィジョンBの違いの完全なリストである。 +
-This is a complete list of differences between <<Divisions, division>> A and <<Divisions, division>> B.
+これは、<<ディヴィジョン/Divisions, ディヴィジョン>>Aと<<ディヴィジョン/Divisions, ディヴィジョン>>Bの違いの完全なリストである。 +
+This is a complete list of differences between <<ディヴィジョン/Divisions, division>> A and <<ディヴィジョン/Divisions, division>> B.
 
-* ディヴィジョンAはディヴィジョンBよりも大きなフィールドとlarger ゴールで試合を行う。その結果、シュートアウトもより遠くから行われる。 +
-Division A plays on a <<Dimensions, larger field>> with <<Goals, larger goals>> than division B. As a result, the <<Shoot-Out, shoot-out>> is taken from a greater distance as well.
-* ディヴィジョンAはディヴィジョンBよりも多いロボットで試合を行う。 +
-Division A plays with <<Number Of Robots, more robots>> than division B.
-* ボール配置の手順はディヴィジョンAでは必須であり、ディヴィジョンBでは任意である。 +
-The automatic <<Ball Placement, ball placement>> procedure is mandatory for division A and optional for division B.
-* 無意味なキックのルールはディヴィジョンBにのみ適用される。 +
-The <<Aimless Kick [small]#(_division B only_)#, aimless kick>> rule only applies to division B.
-* ディヴィジョンAには進行の欠如が呼び出されるより前にフリーキックをするための小さな時間枠がある。 +
-There is a smaller time window in division A for taking a free kick before <<Lack Of Progress, lack of progress>> is called.
+* ディヴィジョンAはディヴィジョンBよりも<<フィールドの大きさ/Dimensions, 大きなフィールド>>と<<ゴール/Goals, 大きなゴール>>で試合を行う。その結果、<<シュートアウト/Shoot-Out, シュートアウト>>もより遠くから行われる。 +
+Division A plays on a <<フィールドの大きさ/Dimensions, larger field>> with <<ゴール/Goals, larger goals>> than division B. As a result, the <<シュートアウト/Shoot-Out, shoot-out>> is taken from a greater distance as well.
+* ディヴィジョンAはディヴィジョンBよりも<<ロボットの台数/Number Of Robots, 多いロボット>>で試合を行う。 +
+Division A plays with <<ロボットの台数/Number Of Robots, more robots>> than division B.
+* <<ボール配置/Ball Placement, ボール配置>>の手順はディヴィジョンAでは必須であり、ディヴィジョンBでは任意である。 +
+The automatic <<ボール配置/Ball Placement, ball placement>> procedure is mandatory for division A and optional for division B.
+* <<エイムレスキック/Aimless Kick [small]#(_division B only_)#, エイムレスキック>>のルールはディヴィジョンBにのみ適用される。 +
+The <<エイムレスキック/Aimless Kick [small]#(_division B only_)#, aimless kick>> rule only applies to division B.
+* ディヴィジョンAには<<進行の欠落/Lack Of Progress, 進行の欠如>>が呼び出されるより前にフリーキックをするための小さな時間枠がある。 +
+There is a smaller time window in division A for taking a free kick before <<進行の欠落/Lack Of Progress, lack of progress>> is called.

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -308,5 +308,5 @@ Division A plays with <<ロボットの台数/Number Of Robots, more robots>> th
 The automatic <<ボール配置/Ball Placement, ball placement>> procedure is mandatory for division A and optional for division B.
 * <<エイムレスキック/Aimless Kick [small]#(_division B only_)#, エイムレスキック>>のルールはディヴィジョンBにのみ適用される。 +
 The <<エイムレスキック/Aimless Kick [small]#(_division B only_)#, aimless kick>> rule only applies to division B.
-* ディヴィジョンAには<<進行の欠落/Lack Of Progress, 進行の欠如>>が呼び出されるより前にフリーキックをするための小さな時間枠がある。 +
+* ディヴィジョンAには<<進行の欠落/Lack Of Progress, 進行の欠落>>が呼び出されるより前にフリーキックをするための小さな時間枠がある。 +
 There is a smaller time window in division A for taking a free kick before <<進行の欠落/Lack Of Progress, lack of progress>> is called.

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -158,8 +158,8 @@ Chapter <<反則/Offenses>>, section <<軽微な違反/Minor Offenses>>:
 | <<停止/Stop, ストップ>>、次いで<<間接フリーキック/Direct Free Kick, 間接フリーキック>> +
 <<停止/Stop, Stop>>, then <<間接フリーキック/Indirect Free Kick, Indirect Free Kick>> 
 | icon:check[role="green"]
-| <<ディフェンスエリアにあるアタッカー/Attacker In Defense Area, ディフェンスエリアにあるアタッカー>> +
- <<ディフェンスエリアにあるアタッカー/Attacker In Defense Area, Attacker In Defense Area>>
+| <<アタッカーの相手ディフェンスエリアへの侵入/Attacker In Defense Area, アタッカーの相手ディフェンスエリアへの侵入>> +
+ <<アタッカーの相手ディフェンスエリアへの侵入/Attacker In Defense Area, Attacker In Defense Area>>
 | <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中 +
 <<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> 
 | <<停止/Stop, ストップ>>、次いで<<間接フリーキック/Direct Free Kick, 間接フリーキック>> +

--- a/chapters/ballleavesthefield.adoc
+++ b/chapters/ballleavesthefield.adoc
@@ -1,49 +1,49 @@
 == フィールド外に出るボール/Ball Leaves The Field
-ボールがフィールドラインを完全に横切ってフィールド外に出た場合、試合は停止され、ボールが配置されてから、ボールがフィールドラインを横切った位置と最後にボールに触れたチームに応じて試合が再開する。 +
-When the ball leaves the field by fully crossing the <<Field Lines, field line>>, the game will be stopped, the ball will be placed and the game will be restarted depending on the position of the field line crossing as well as on the team that last touched the ball.
+ボールが<<フィールドライン/Field Lines, フィールドライン>>を完全に横切ってフィールド外に出た場合、試合は停止され、ボールが配置されてから、ボールがフィールドラインを横切った位置と最後にボールに触れたチームに応じて試合が再開する。 +
+When the ball leaves the field by fully crossing the <<フィールドライン/Field Lines, field line>>, the game will be stopped, the ball will be placed and the game will be restarted depending on the position of the field line crossing as well as on the team that last touched the ball.
 
 === タッチラインとの交差/Touch Line Crossing
-タッチラインはフィールドの両サイドにある長いフィールドラインである。 +
-Touch lines are the long <<Field Lines, field lines>> at both sides of the playing field.
+タッチラインはフィールドの両サイドにある長い<<フィールドライン/Field Lines, フィールドライン>>である。 +
+Touch lines are the long <<フィールドライン/Field Lines, field lines>> at both sides of the playing field.
 
 ==== スローイン/Throw-In
 .定義/Definition
 ボールはボールが横切った側のタッチラインから垂直に0.2mの位置に配置する必要がある。ゴールラインまでの距離は少なくとも0.2mは無くてはいけない。 +
 The ball has to be placed 0.2 meters perpendicular to the touch line where the ball crossed the touch line. Its distance to the goal lines must be at least 0.2 meters.
 
-ボールが設置されたのち、フィールドを離れる前の最後にボールに触れたチームの相手チームに対して間接フリーキックが与えられる。 +
-After the ball has been placed, an <<Indirect Free Kick, indirect free kick>> is awarded to the opponent of the team that last touched the ball before it left the field.
+ボールが設置されたのち、フィールドを離れる前の最後にボールに触れたチームの相手チームに対して<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>が与えられる。 +
+After the ball has been placed, an <<間接フリーキック/Indirect Free Kick, indirect free kick>> is awarded to the opponent of the team that last touched the ball before it left the field.
 
 .用途/Usage
 スローインはボールがタッチラインを横切ってフィールドを離れた後にゲームを再開するために使用される。 +
 A throw-in is used to restart the game after the ball left the field by crossing the touch line.
 
 === ゴールラインとの交差/Goal Line Crossing
-ゴールラインはフィールド両端にある短いフィールドラインである。 +
-Goal lines are the short <<Field Lines, field lines>> at both ends of the playing field.
+ゴールラインはフィールド両端にある短い<<フィールドライン/Field Lines, フィールドライン>>である。 +
+Goal lines are the short <<フィールドライン/Field Lines, field lines>> at both ends of the playing field.
 
 ==== ゴールキック/Goal Kick
 .定義/Definition
 ボールはボールが横切った位置から近いほうのタッチラインから0.2m、ゴールラインから1mの位置に配置する必要がある。 +
 The ball has to be placed 0.2 meters from the closest touch line and 1 meter from the goal line.
 
-ボールが設置されたのち、フィールドを離れる前の最後にボールに触れたチームの相手チームに対して直接フリーキックが与えられる。 +
-After the ball has been placed, a <<Direct Free Kick, direct free kick>> is awarded to the opponent of the team that last touched the ball before it left the field.
+ボールが設置されたのち、フィールドを離れる前の最後にボールに触れたチームの相手チームに対して<<直接フリーキック/Direct Free Kick, 直接フリーキック>>が与えられる。 +
+After the ball has been placed, a <<直接フリーキック/Direct Free Kick, direct free kick>> is awarded to the opponent of the team that last touched the ball before it left the field.
 
 .用途/Usag
 ゴールキックはボールが最後にボールに触れなかったチームのゴールラインを横切ってフィールドを離れた後にゲームを再開するために使用される。 +
 A goal kick is used to restart the game after the ball left the field by crossing the goal line of the team that did not touch the ball last.
 
-NOTE: ディヴィジョンB では、aimless kick ruleが適用されるかもしれない。 +
-In division B, the <<Aimless Kick [small]#(_division B only_)#, aimless kick rule>> might apply instead.
+NOTE: ディヴィジョンB では、<<エイムレスキック/Aimless Kick [small]#(_division B only_)#, エイムレスキック>>が適用されるかもしれない。 +
+In division B, the <<エイムレスキック/Aimless Kick [small]#(_division B only_)#, aimless kick rule>> might apply instead.
 
 ==== コーナーキック/Corner Kick
 .定義/Definition
 ボールはボールが横切った位置から近いほうのタッチラインから0.2m、ゴールラインから0.2mの位置に配置する必要がある。 +
 The ball has to be placed 0.2 meters from the closest touch line and 0.2 meters from the goal line.
 
-ボールが設置されたのち、フィールドを離れる前の最後にボールに触れたチームの相手チームに対して直接フリーキックが与えられる。 +
-After the ball has been placed, a <<Direct Free Kick, direct free kick>> is awarded to the opponent of the team that last touched the ball before it left the field.
+ボールが設置されたのち、フィールドを離れる前の最後にボールに触れたチームの相手チームに対して<<直接フリーキック/Direct Free Kick,直接フリーキック>>が与えられる。 +
+After the ball has been placed, a <<直接フリーキック/Direct Free Kick, direct free kick>> is awarded to the opponent of the team that last touched the ball before it left the field.
 
 .用途/Usage
 コーナーキックはボールが最後に触れたチームのゴールラインを横切ってフィールドを離れた後にゲームを再開するために使用される。 +

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -4,7 +4,7 @@
 To play an official match in the Small Size League, four impartial roles must be filled:
 
 * <<主審/Referee>>
-* <<副審/Assistant Referee>>)
+* <<副審/Assistant Referee>>
 * <<Game Controller Operator>>
 * <<Vision Expert>>
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -3,22 +3,22 @@
 小型機リーグの公式な試合を行うためには、4人の公平な役割を揃えなければいけない。 +
 To play an official match in the Small Size League, four impartial roles must be filled:
 
-* 主審(the <<Referee, referee>>)
-* 副審(the <<Assistant Referee, assistant referee>>)
-* game controller operator(the <<Game Controller Operator, game controller operator>>)
-* vision expert(the <<Vision Expert, vision expert>>)
+* <<主審/Referee>>
+* <<副審/Assistant Referee>>)
+* <<Game Controller Operator>>
+* <<Vision Expert>>
 
-通常、これらの役割は、試合に出場していない2チームによって行われる。1チーム目は主審とgame controller operatorを、2チーム目は副審とvision expertを担当する。これらの役割は組織委員会によって割り当てられる。 +
-Usually, these roles are filled by two non-playing teams, with one team providing the <<Referee, referee>> and the <<Game Controller Operator, game controller operator>> and the other team providing the <<Assistant Referee, assistant referee>> and the <<Vision Expert, vision expert>>. The assignment of the roles is up to the <<Organizing Committee, organizing committee>>.
+通常、これらの役割は、試合に出場していない2チームによって行われる。1チーム目は<<主審/Referee, 主審>>と<<Game Controller Operator, game controller operator>> を、2チーム目は<<副審/Assistant Referee, 副審>>と<<Vision Expert, vision expert>>を担当する。これらの役割は<<組織委員会/Organizing Committee, 組織委員会>>によって割り当てられる。 +
+Usually, these roles are filled by two non-playing teams, with one team providing the <<主審/Referee, referee>> and the <<Game Controller Operator, game controller operator>> and the other team providing the <<副審/Assistant Referee, assistant referee>> and the <<Vision Expert, vision expert>>. The assignment of the roles is up to the <<組織委員会/Organizing Committee, organizing committee>>.
 
-すべての参加するチームはこれらの役割に精通した十分な人材を提供できることが求められる。
+すべての参加するチームはこれらの役割に精通した十分な人材を提供できることが求められる。 +
 Every participating team is required to be able to provide enough people who are familiar with these roles.
 
 ==== 主審/Referee
-各試合は主審によってコントロールされる。主審は任命された試合に関して競技規則を施行する一切の権限を持つ。主審はフィールド横にある歩行エリアを使うことが推奨される(フィールドセットアップを参照)。 +
-Each match is controlled by the referee. He has full authority to enforce the rules of the Small Size League in connection with the match to which he has been appointed. The referee is encouraged to use the designated walking area next to the field (see <<Field Setup>>).
+各試合は主審によってコントロールされる。主審は任命された試合に関して競技規則を施行する一切の権限を持つ。主審はフィールド横にある歩行エリアを使うことが推奨される(「<<フィールドセットアップ/Field Setup,フィールドセットアップ>>」を参照)。 +
+Each match is controlled by the referee. He has full authority to enforce the rules of the Small Size League in connection with the match to which he has been appointed. The referee is encouraged to use the designated walking area next to the field (see [<<フィールドセットアップ/Field Setup, Field Setup>>]).
 
-主審はautomatic refereeソフトウェアによって支援される。人間の主審はautomatic refereeによって生成されたいかなる決定も上書きすることが許可されている。 +
+主審は<<Automatic Referee, automatic referee>>ソフトウェアによって支援される。人間の主審はautomatic refereeによって生成されたいかなる決定も上書きすることが許可されている。 +
 The referee is assisted by the <<Automatic Referee, automatic referee>> software. The human referee is allowed to override any decision made by the automatic referee software.
 
 プレーに関する事実についての主審の決定は、最終的なものである。プレーを再開する前、または試合を終結する前であれば、主審は、その直前の決定が正しくないことに気づいたとき、または主審の裁量によって副審の助言を採用したときのみ、決定を変えることができる。 +
@@ -28,8 +28,8 @@ advice of an assistant referee, provided that he has not restarted play.
 主審は、次に示すことに法的な責任を負わない。役員または観客のあらゆる怪我、あらゆる種類の財産への損害、個人、クラブ、会社、協会、またはその他の団体に対するその他の損失 +
 The referee is not held liable for any kind of injury suffered by an official or spectator, any damage to property of any kind nor any other loss suffered by an individual, club, company, association, or other body.
 
-ハンドラは主審と話すことができる唯一のチームメンバーである。 +
-The <<Robot Handler, robot handler>> is the only team member that may talk to the referee.
+<<ハンドラ/Robot Handler, ハンドラ>>は主審と話すことができる唯一のチームメンバーである。 +
+The <<ハンドラ/Robot Handler, robot handler>> is the only team member that may talk to the referee.
 
 .職務/Duties
 
@@ -39,14 +39,14 @@ The referee ensures a safe match for all humans and robots
 The referee ensures a fair match according to the rules of the Small Size League
 * 主審は許可されていない人間やチームメンバーによる干渉が発生していないことを確かめる +
 The referee ensures that there is no interference by unauthorized persons or team members
-* 主審か副審はキックオフやペナルティキック(ディヴィジョンA)もしくは試合の停止(ディヴィジョンB)の時にボールを配置する。その後、主審は試合を再開する。 +
-The referee or assistant referee places the ball for <<Kick-Off, kick-offs>> and <<Penalty Kick, penalties>> (division A) or after every <<Stopping The Game, stoppage>> (division B). Subsequently, the referee resumes the match
+* 主審か副審は<<キックオフ/Kick-Off, キックオフ>>や<<ペナルティーキック/Penalty Kick, ペナルティーキック>> (ディヴィジョンA)もしくは<<試合の停止/Stopping The Game,試合の停止>>(ディヴィジョンB)の時にボールを配置する。その後、主審は試合を再開する。 +
+The referee or assistant referee places the ball for <<キックオフ/Kick-Off, kick-offs>> and <<ペナルティーキック/Penalty Kick, penalties>> (division A) or after every <<試合の停止/Stopping The Game, stoppage>> (division B). Subsequently, the referee resumes the match
 * 主審は時間内に試合が開始もしくは再開されることを確かめる +
 The referee ensures that the game is started and resumed in time
 
 ==== 副審/Assistant Referee
-副審はどこでも可能な限り主審の補助をする。副審は主審と反対側のフィールド横にある歩行エリアを使うことが推奨される。 +
-The assistant referee supports the referee wherever he can. He is encouraged to use the designated walking area next to the <<Field Setup, field>>, opposite the referee.
+副審はどこでも可能な限り主審の補助をする。副審は主審と反対側の<<フィールドセットアップ/Field Setup, フィールド>>横にある歩行エリアを使うことが推奨される。 +
+The assistant referee supports the referee wherever he can. He is encouraged to use the designated walking area next to the <<フィールドセットアップ/Field Setup, field>>, opposite the referee.
 
 いかなるチームメンバーも副審と会話することは許可されない。 +
 No team members are allowed to talk to the assistant referee.
@@ -57,24 +57,24 @@ No team members are allowed to talk to the assistant referee.
 The assistant referee indicates when misconduct or any other incident has occurred out of the view of the referee
 * 副審は主審と不明確な状況について議論をする +
 The assistant referee discusses unclear situations with the referee
-* 主審か副審はキックオフやペナルティキック(ディヴィジョンA)もしくは試合の停止(ディヴィジョンB)の時にボールを配置する。その後、主審は試合を再開する +
-The referee or assistant referee places the ball for <<Kick-Off, kick-offs>> and <<Penalty Kick, penalties>> (division A) or after every <<Stopping The Game, stoppage>> (division B)
+* 主審か副審はキックオフやペナルティーキック(ディヴィジョンA)もしくは試合の停止(ディヴィジョンB)の時にボールを配置する。その後、主審は試合を再開する +
+The referee or assistant referee places the ball for <<キックオフ/Kick-Off, kick-offs>> and <<ペナルティーキック/Penalty Kick, penalties>> (division A) or after every <<試合の停止/Stopping The Game, stoppage>> (division B)
 
 
 ==== Game Controller Operator
-競技中、game controller operatorは主審、automatic refereeと各チームのソフトウェアの間のインターフェースとなるgame controller softwareを使用する。 +
-During a match, the game controller operator uses the <<Game Controller, game controller software>> as an interface between the <<Referee, referee>>, the <<Automatic Referee, automatic referee>> and the team software.
+競技中、game controller operatorは<<主審/Referee, 主審>>、<<Automatic Referee, automatic referee>>と各チームのソフトウェアの間のインターフェースとなる<<Game Controller, game controller software>>を使用する。 +
+During a match, the game controller operator uses the <<Game Controller, game controller software>> as an interface between the <<主審/Referee, referee>>, the <<Automatic Referee, automatic referee>> and the team software.
 
 ハンドラがロボットの交代をする時を除いて、いかなるチームメンバーもgame controller operatorと会話することは許可されない。 +
-No team members are allowed to talk to the game controller operator, except the <<Robot Handler, robot handler>> for <<Robot Substitution, robot substitution>> intents.
+No team members are allowed to talk to the game controller operator, except the <<ハンドラ/Robot Handler, robot handler>> for <<ロボットの交代/Robot Substitution, robot substitution>> intents.
 
 .職務/Duties
 * game controller operatorはgame controllerを試合前に設定する +
 The game controller operator configures the <<Game Controller, game controller>> before the game begins
 * game controller operatorは主審からの合図をgame controllerに入力する +
-The game controller operator enters the signals of the <<Referee, referee>> into the <<Game Controller, game controller>>
+The game controller operator enters the signals of the <<主審/Referee, referee>> into the <<Game Controller, game controller>>
 * game controller operatorは注意を必要とするあらゆるゲームイベントログ(automatic refereeや試合の経過時間など)を監視し、主審に通知する +
-The game controller operator watches the game event log for any events that need attention, like detections of an <<Automatic Referee, automatic referee>> or elapsed timers and notifies the <<Referee, referee>>
+The game controller operator watches the game event log for any events that need attention, like detections of an <<Automatic Referee, automatic referee>> or elapsed timers and notifies the <<主審/Referee, referee>>
 
 NOTE: (訳者注)日本では一般的に「レフボ」と呼称されることが多い。これは、同様の機能を持った旧世代のソフトウェアである「ssl-refbox」、およびその操作担当である「refbox operator」(2018年の大会をもって廃止)に由来する。
 
@@ -87,8 +87,8 @@ Team members are generally advised not to talk to the vision expert, unless they
 
 .職務/Duties
 
-* Vision expartはVisionのハードウェアをチェックし、あらゆる種類のハードウェアの問題を技術委員会に報告する。 +
-The vision expert checks the vision hardware and reports any kind of hardware problems to the <<Technical Committee, technical committee>>
+* Vision expartはVisionのハードウェアをチェックし、あらゆる種類のハードウェアの問題を<<技術委員会/Technical Committee, 技術委員会>>に報告する。 +
+The vision expert checks the vision hardware and reports any kind of hardware problems to the <<技術委員会/Technical Committee, technical committee>>
 * Vision expartは試合中に共有Visionシステムを監視し、あらゆる種類の問題を主審に即座に報告する。 +
 The vision expert monitors the shared vision system during the match and reports any kind of problems to the referee instantly
 * 主審が必要であると考えた場合には、Vision expartはVision systemを再キャリブレーションする。 +
@@ -103,44 +103,44 @@ NOTE: (訳者注)日本では一般的に「ビジョン」と呼称されるこ
 Before the start of the match, every team has to designate one robot handler. The robot handler represents the team during the match.
 
 .職務/Duties
-* ハンドラーは競技の準備の補助を行う。 +
-The robot handler helps <<Match Preparation, preparing the match>>.
-* 必要であれば、ハンドラーは主審にタイムアウトを要求する。 +
-The robot handler asks the referee for <<Timeouts, timeouts>> if necessary.
-* ハンドラーは次のStop Game時にロボットを交代する許可を主審に要求し、主審が許可した場合はロボットを交代する。 +
-The robot handler asks the referee for the permission to substitute a robot in the next stoppage and, if the referee agrees, <<Robot Substitution, substitutes the robot>>.
+* ハンドラーは<<競技の準備/Match Preparation, 競技の準備>>の補助を行う。 +
+The robot handler helps <<競技の準備/Match Preparation, preparing the match>>.
+* 必要であれば、ハンドラーは主審に<<タイムアウト/Timeouts, タイムアウト>>を要求する。 +
+The robot handler asks the referee for <<タイムアウト/Timeouts, timeouts>> if necessary.
+* ハンドラーは次のStop Game時にロボットを交代する許可を主審に要求し、主審が許可した場合は<<ロボットの交代/Robot Substitution,ロボットを交代する>>。 +
+The robot handler asks the referee for the permission to substitute a robot in the next stoppage and, if the referee agrees, <<ロボットの交代/Robot Substitution, substitutes the robot>>.
 * ハンドラはチームの懸念事項を表明する(例えばネットワークやビジョンの問題)。 +
 The robot handler voices concerns of the team (for example network issues or vision problems).
 
 === 競技の準備/Match Preparation
-競技で役割のあるすべての人間(公平な役割とチーム固有の役割)は、主審が次の準備を可能にするために、少なくとも試合開始の10分前には準備できていなければならない: +
-All people that fill a role in the match (<<Impartial Roles, impartial>> or <<Team-Specific Roles, team-specific>>) have to be ready at least 10 minutes before the start of the match to allow the referee to make the following preparations:
+競技で役割のあるすべての人間(「<<公正な役割/Impartial Roles, 公平な役割>>」もしくは「<<チーム固有の役割/Team-Specific Roles, チーム固有の役割>>」を参照)は、主審が次の準備を可能にするために、少なくとも試合開始の10分前には準備できていなければならない: +
+All people that fill a role in the match (<<公正な役割/Impartial Roles, impartial>> or <<チーム固有の役割/Team-Specific Roles, team-specific>>) have to be ready at least 10 minutes before the start of the match to allow the referee to make the following preparations:
 
 ==== Game Result Sheet
-主審は組織委員会からGame Result Sheetを受け取る。試合後に、主審は最終結果を記入し、必要な署名を集めてSheetを組織委員会に提出する。 +
-The <<Referee, referee>> obtains a game result sheet from the <<Organizing Committee, organizing committee>>. After the game, the referee fills in the final score, collects the required signatures and submits the sheet to the <<Organizing Committee, organizing committee>>.
+<<主審/Referee, 主審>>は<<組織委員会/Organizing Committee, 組織委員会>>からGame Result Sheetを受け取る。試合後に、主審は最終結果を記入し、必要な署名を集めてSheetを<<組織委員会/Organizing Committee, 組織委員会>>に提出する。 +
+The <<主審/Referee, referee>> obtains a game result sheet from the <<組織委員会/Organizing Committee, organizing committee>>. After the game, the referee fills in the final score, collects the required signatures and submits the sheet to the <<組織委員会/Organizing Committee, organizing committee>>.
 
-NOTE: Game Result Sheetを受け取っている間、主審は公式球と(もし提供されるのであれば)ホイッスルやレッドカードイエローカードなどの審判向けの機器も使用できる。 +
-While obtaining the game result sheet, the referee can also take an official <<Ball, ball>> and referee equipment such as a whistle or red and yellow cards (if provided).
+NOTE: Game Result Sheetを受け取っている間、主審は<<ボール/Ball, 公式球>>と(もし提供されるのであれば)ホイッスルやレッドカードイエローカードなどの審判向けの機器も使用できる。 +
+While obtaining the game result sheet, the referee can also take an official <<ボール/Ball, ball>> and referee equipment such as a whistle or red and yellow cards (if provided).
 
 ==== ネットワークのテスト/Testing The Network
-主審は両方のチームがVisionデータとレフェリーコマンドを受信できるか確認する。 +
-The <<Referee, referee>> ensures that both teams receive vision data and referee commands.
+<<主審/Referee, 主審>>は両方のチームがVisionデータとレフェリーコマンドを受信できるか確認する。 +
+The <<主審/Referee, referee>> ensures that both teams receive vision data and referee commands.
 
 ==== チームカラーの選択/Choosing Team Colors
-主審は両チームのハンドラに希望するチームカラー(青か黄色のどちらか)を確認する。両チームが色の割り当てに同意するのであれば、競技全体でその色が使用される。 +
-The <<Referee, referee>> asks the <<Robot Handler, robot handlers>> of the teams about their preferred team color (either blue or yellow). If the teams agree on a color assignment, the colors will be used for the entire match.
+<<主審/Referee, 主審>>は両チームの<<ハンドラ/Robot Handler, ハンドラ>>に希望するチームカラー(青か黄色のどちらか)を確認する。両チームが色の割り当てに同意するのであれば、競技全体でその色が使用される。 +
+The <<主審/Referee, referee>> asks the <<ハンドラ/Robot Handler, robot handlers>> of the teams about their preferred team color (either blue or yellow). If the teams agree on a color assignment, the colors will be used for the entire match.
 
 しかし、両チームが同じ色を希望した場合は、主審は色を任意に割り当てる。この場合、両チームは前半戦と可能であればオーバータイムの前半戦の後に色を入れ替える。 +
 However, if both teams prefer the same color, the referee assigns the colors by chance. In this case, the teams switch the colors after the first half of the match as well as after the first half of the overtime if applicable.
 
 ==== 陣地とキックオフの選択/Choosing Side And Kick-Off
-主審は両チームのハンドラと一緒にコイントスを行う。コイントスの勝者が前半戦で攻めるゴールを選ぶ。もう一方のチームが前半戦開始時のキックオフを行う。 +
-The <<Referee, referee>> tosses a coin with both <<Robot Handler, robot handlers>>. The winning team chooses the goal it will attack in the first half of the match. The other team takes the <<Kick-Off, kick-off>> to start the match.
+<<主審/Referee, 主審>>は両チームの<<ハンドラ/Robot Handler, ハンドラ>>と一緒にコイントスを行う。コイントスの勝者が前半戦で攻めるゴールを選ぶ。もう一方のチームが前半戦開始時の<<キックオフ/Kick-Off, キックオフ>>を行う。 +
+The <<主審/Referee, referee>> tosses a coin with both <<ハンドラ/Robot Handler, robot handlers>>. The winning team chooses the goal it will attack in the first half of the match. The other team takes the <<キックオフ/Kick-Off, kick-off>> to start the match.
 
 ==== ゴールキーパーのIDの選択/Choosing Keeper Id
-主審は両チームのハンドラにどのロボットをキーパーとして使用するつもりなのか確認し、game controller operatorに情報を連絡する。 +
-The <<Referee, referee>> asks both <<Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
+<<主審/Referee, 主審>>は両チームの<<ハンドラ/Robot Handler, ハンドラ>>にどのロボットをキーパーとして使用するつもりなのか確認し、<<Game Controller Operator, game controller operator>>に情報を連絡する。 +
+The <<主審/Referee, referee>> asks both <<ハンドラ/Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
 
 NOTE: もしチームがキーパーを使用したくない場合、フィールド上に存在しないロボットのIDを選択すること。 +
 If a team does not want to use a keeper, it may select the id of a robot that is not on the field.
@@ -177,20 +177,20 @@ If the score is even after overtime has been played, the following stages are ad
 | Game Stage | 期間(Duration)
 
 | シュートアウトの準備(Pre-Shoot-Out Break) | 120秒の休憩(120 seconds of pause)
-| シュートアウト<<Shoot-Out>> | 無制限(unlimited)
+| <<シュートアウト/Shoot-Out, シュートアウト(Shoot-Out)>> | 無制限(unlimited)
 |===
 
-競技のタイマーは両チームともボールを操作することが許されない場合に一時停止される。これにはstop、halt、kick-offとpenalty kickの準備時間が含まれる。さらにball placement中もタイマーは一時停止される。 +
-The match timer is paused whenever no team is allowed to <<Ball Manipulation, manipulate the ball>>. This includes <<Stop, stop>>, <<Halt, halt>> and the preparation states of <<Kick-Off, kick-off>> and <<Penalty Kick, penalty kick>>. Additionally, it is paused during <<Ball Placement, ball placement>>.
+競技のタイマーは両チームとも<<ボールの操作/Ball Manipulation,ボールを操作する>>ことが許されない場合に一時停止される。これには<<停止/Stop, ストップゲーム>>、<<ハルト/Halt, ハルト>>、<<キックオフ/Kick-Off, キックオフ>>と<<ペナルティーキック/Penalty Kick,ペナルティーキック>>の準備時間が含まれる。さらに<<ボール配置/Ball Placement, ボール配置中>>もタイマーは一時停止される。 +
+The match timer is paused whenever no team is allowed to <<ボールの操作/Ball Manipulation, manipulate the ball>>. This includes <<停止/Stop, stop>>, <<ハルト/Halt, halt>> and the preparation states of <<キックオフ/Kick-Off, kick-off>> and <<ペナルティーキック/Penalty Kick, penalty kick>>. Additionally, it is paused during <<ボール配置/Ball Placement, ball placement>>.
 
 NOTE: この結果、試合に必要な時間は競技時間よりもはるかに長くなる。 +
 As a result, the time needed for a match is much greater than the playing time.
 
 ==== タイムアウト/Timeouts
-タイムアウトを取りたい時、ハンドラは主審に確認をとらなければならない。タイムアウトは休憩のように扱われ、両チームとも自らのソフトウェアとハードウェアの修正を行うことが許可されている(自律性を参照)。 +
-The <<Robot Handler, robot handler>> has to ask the referee for a timeout. Timeouts are handled like <<Overview, breaks>>, meaning that both teams are allowed to make modifications to their software and hardware (see <<Autonomy>>).
+タイムアウトを取りたい時、<<ハンドラ/Robot Handler, ハンドラ>>は主審に確認をとらなければならない。タイムアウトは<<概要/Overview, 休憩>>のように扱われ、両チームとも自らのソフトウェアとハードウェアの修正を行うことが許可されている(「<<自律性/Autonomy, 自律性>>」を参照)。 +
+The <<ハンドラ/Robot Handler, robot handler>> has to ask the referee for a timeout. Timeouts are handled like <<概要/Overview, breaks>>, meaning that both teams are allowed to make modifications to their software and hardware (see <<自律性/Autonomy,Autonomy>>).
 
-どちらのチームも競技開始から4回までのタイムアウトが割り当てられている。すべてのタイムアウトの合計は300秒まで許されている。タイムアウトはstop game中のみ取得することができる。時間はgame controller operatorによって監視と記録がされている。 +
+どちらのチームも競技開始から4回までのタイムアウトが割り当てられている。すべてのタイムアウトの合計は300秒まで許されている。タイムアウトはstop game中のみ取得することができる。時間は<<Game Controller Operator, game controller operator>>によって監視と記録がされている。 +
 Each team is allocated 4 timeouts at the beginning of the match. A total of 300 seconds is allowed for all timeouts. Timeouts may only be taken during a game
 stoppage. The time is monitored and recorded by the <<Game Controller Operator, game controller operator>>.
 
@@ -200,8 +200,8 @@ For example, a team may take 3 timeouts of 60 seconds duration and thereafter ha
 延長戦の間は、両チームとも合計150秒間で2回のタイムアウトを取得できる。レギュラーゲームで使われなかったタイムアウトの回数と時間は加算されない。 +
 During overtime, both teams can use 2 timeouts with a total time of 150 seconds. The number of timeouts and the time not used in regular game are not added.
 
-シュートアウトの間はタイムアウトを取得できない。 +
-No timeouts are possible in the <<Shoot-Out, shoot-out>> stage.
+<<シュートアウト/Shoot-Out, シュートアウト>>の間はタイムアウトを取得できない。 +
+No timeouts are possible in the <<シュートアウト/Shoot-Out, shoot-out>> stage.
 
 ==== 10点先取による早期終了/Early Termination At A Score Of 10
 片方のチームが10回シュートを決めた場合、試合は自動的に終了し、現在のゲームステージに関係なく、より多くゴールをしたチームが勝者と宣言される。 +

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -99,15 +99,15 @@ NOTE: (訳者注)日本では一般的に「ビジョン」と呼称されるこ
 === チーム固有の役割/Team-Specific Roles
 
 ==== ハンドラ/Robot Handler
-試合開始前に、すべてのチームは一人のハンドラーを指定しなければいけない。ハンドラーは試合中にチームを代表する。 +
+試合開始前に、すべてのチームは一人のハンドラを指定しなければいけない。ハンドラは試合中にチームを代表する。 +
 Before the start of the match, every team has to designate one robot handler. The robot handler represents the team during the match.
 
 .職務/Duties
-* ハンドラーは<<競技の準備/Match Preparation, 競技の準備>>の補助を行う。 +
+* ハンドラは<<競技の準備/Match Preparation, 競技の準備>>の補助を行う。 +
 The robot handler helps <<競技の準備/Match Preparation, preparing the match>>.
-* 必要であれば、ハンドラーは主審に<<タイムアウト/Timeouts, タイムアウト>>を要求する。 +
+* 必要であれば、ハンドラは主審に<<タイムアウト/Timeouts, タイムアウト>>を要求する。 +
 The robot handler asks the referee for <<タイムアウト/Timeouts, timeouts>> if necessary.
-* ハンドラーは次のStop Game時にロボットを交代する許可を主審に要求し、主審が許可した場合は<<ロボットの交代/Robot Substitution,ロボットを交代する>>。 +
+* ハンドラは次のStop Game時にロボットを交代する許可を主審に要求し、主審が許可した場合は<<ロボットの交代/Robot Substitution,ロボットを交代する>>。 +
 The robot handler asks the referee for the permission to substitute a robot in the next stoppage and, if the referee agrees, <<ロボットの交代/Robot Substitution, substitutes the robot>>.
 * ハンドラはチームの懸念事項を表明する(例えばネットワークやビジョンの問題)。 +
 The robot handler voices concerns of the team (for example network issues or vision problems).

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -116,11 +116,11 @@ The robot handler voices concerns of the team (for example network issues or vis
 競技で役割のあるすべての人間(「<<公正な役割/Impartial Roles, 公平な役割>>」もしくは「<<チーム固有の役割/Team-Specific Roles, チーム固有の役割>>」を参照)は、主審が次の準備を可能にするために、少なくとも試合開始の10分前には準備できていなければならない: +
 All people that fill a role in the match (<<公正な役割/Impartial Roles, impartial>> or <<チーム固有の役割/Team-Specific Roles, team-specific>>) have to be ready at least 10 minutes before the start of the match to allow the referee to make the following preparations:
 
-==== Game Result Sheet
-<<主審/Referee, 主審>>は<<組織委員会/Organizing Committee, 組織委員会>>からGame Result Sheetを受け取る。試合後に、主審は最終結果を記入し、必要な署名を集めてSheetを<<組織委員会/Organizing Committee, 組織委員会>>に提出する。 +
+==== 試合結果シート/Game Result Sheet
+<<主審/Referee, 主審>>は<<組織委員会/Organizing Committee, 組織委員会>>から試合結果シートを受け取る。試合後に、主審は最終結果を記入し、必要な署名を集めてSheetを<<組織委員会/Organizing Committee, 組織委員会>>に提出する。 +
 The <<主審/Referee, referee>> obtains a game result sheet from the <<組織委員会/Organizing Committee, organizing committee>>. After the game, the referee fills in the final score, collects the required signatures and submits the sheet to the <<組織委員会/Organizing Committee, organizing committee>>.
 
-NOTE: Game Result Sheetを受け取っている間、主審は<<ボール/Ball, 公式球>>と(もし提供されるのであれば)ホイッスルやレッドカードイエローカードなどの審判向けの機器も使用できる。 +
+NOTE: 試合結果シートを受け取っている間、主審は<<ボール/Ball, 公式球>>と(もし提供されるのであれば)ホイッスルやレッドカードイエローカードなどの審判向けの機器も使用できる。 +
 While obtaining the game result sheet, the referee can also take an official <<ボール/Ball, ball>> and referee equipment such as a whistle or red and yellow cards (if provided).
 
 ==== ネットワークのテスト/Testing The Network

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -28,7 +28,7 @@ NOTE: "Qualification Process"(出場資格審査)は参加予定チームによ�
 The local organizing committee is responsible for planning and executing the event itself in accordance with the needs of the different leagues. This includes setting up the team areas (fields, network, tables, whiteboard, screens, etc.), creating a schedule for the event and implementing a safety and security concept.
 
 === ディヴィジョン/Divisions
-小型リーグはディヴィジョンAとディヴィジョンBと呼ばれる2つの分けられたトーナメントに分割される。ディヴィジョンAは先進的なチームを対象としており、それ以外の新しいチームや競争力が弱いチームなどはディヴィジョンBで試合をすることができる。各チームは2つのディヴィジョンのうち1つのみに参加することができる。 +
+小型リーグはディヴィジョンAとディヴィジョンBと呼ばれる2つのトーナメントに分割される。ディヴィジョンAは先進的なチームを対象としており、それ以外の新しいチームや競争力が弱いチームなどはディヴィジョンBで試合をすることができる。各チームは2つのディヴィジョンのうち1つのみに参加することができる。 +
 The Small Size League is divided into two divisions with separate tournaments, namely division A and division B. Division A is aimed at advanced teams whereas new and/or less competitive teams can play in division B. Each team will only play in one of those two divisions.
 
 出場資格審査で使う資料を提出する時、各チームは簡潔な理由をつけてどちらのディヴィジョンで競技したいかも選択すること。<<組織委員会/Organizing Committee, 組織委員会>>のメンバーは最終的な決定をする。出場資格審査の方法に関する情報はロボカップ小型機リーグの公式ウェブサイト(https://ssl.robocup.org) で確認できる。 +

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -1,13 +1,13 @@
 == リーグ概要/League Overview
 === 委員会/Committees
-(ロボカップの他のリークと同じように)小型機リーグは3つの異なる委員会(実行委員会/executive committee,技術委員会/technical committee,組織委員会/organizing committee)で運営されている。これらの委員会はそれぞれ異なる責任を持っている。各委員会の委員はロボカップ小型機リーグの公式ウェブサイト(https://ssl.robocup.org) で確認できる。 +
-The Small Size League (like every other league of the RoboCup) is run by close cooperation of three different committees (<<Executive Committee, executive committee>>, <<Technical Committee, technical committee>> and <<Organizing Committee, organizing committee>>), all with a different set of responsibilities. The members of the respective committees can be found on the official RoboCup Small Size League website (https://ssl.robocup.org).
+(ロボカップの他のリークと同じように)小型機リーグは3つの異なる委員会(<<実行委員会/Executive Committee, 実行委員会>>、<<技術委員会/Technical Committee, 技術委員会>>、<<組織委員会/Organizing Committee, 組織委員会>>)で運営されている。これらの委員会はそれぞれ異なる責任を持っている。各委員会の委員はロボカップ小型機リーグの公式ウェブサイト(https://ssl.robocup.org) で確認できる。 +
+The Small Size League (like every other league of the RoboCup) is run by close cooperation of three different committees (<<実行委員会/Executive Committee, executive committee>>, <<技術委員会/Technical Committee, technical committee>> and <<組織委員会/Organizing Committee, organizing committee>>), all with a different set of responsibilities. The members of the respective committees can be found on the official RoboCup Small Size League website (https://ssl.robocup.org).
 
-NOTE: 実際には、技術委員会と組織委員会に厳密な区別はない。各委員会の委員が協力して業務をこなしている。 +
-In practice, there is no strict separation between the <<Technical Committee, technical>> and the <<Organizing Committee, organizing committee>>. Members of both committees often work together on the joint set of tasks.
+NOTE: 実際には、<<技術委員会/Technical Committee, 技術委員会>>と<<組織委員会/Organizing Committee, 組織委員会>>に厳密な区別はない。各委員会の委員が協力して業務をこなしている。 +
+In practice, there is no strict separation between the <<技術委員会/Technical Committee, technical>> and the <<組織委員会/Organizing Committee, organizing committee>>. Members of both committees often work together on the joint set of tasks.
 
-それに加えて、地域の組織委員会/local organizing committeeの委員がロボカップのすべてのリーグのイベントを整備している。 +
-Additionally, the members of the <<Local Organizing Committee, local organizing committee>> organize the RoboCup event for all leagues.
+それに加えて、<<地域の組織委員会/Local Organizing Committee, 地域の組織委員会>>の委員がロボカップのすべてのリーグのイベントを整備している。 +
+Additionally, the members of the <<地域の組織委員会/Local Organizing Committee, local organizing committee>> organize the RoboCup event for all leagues.
 
 ==== 実行委員会/Executive Committee
 実行委員会の委員は小型機リーグの長期的目標を担当しており、ロボカップ委員会だけでなく、他のリーグとの提携も行っている。実行委員会は小型機リーグとその成果を毎年ロボカップ委員会に報告し、リーグを組織するためのフィードバッグを得る。実行委員会の委員はロボカップ委員会の理事会によって選出される。委員は3年間の任期を務める。 +
@@ -18,8 +18,8 @@ Executive committee members are responsible for the long term goals of the Small
 The technical committee of the Small Size League is responsible for the technical aspects of the RoboCup, such as maintaining the rules and the shared software. All members are elected by the team leaders of the teams which have participated in the previous competition.
 
 ==== 組織委員会/Organizing Committee
-小型機リーグの組織委員会は競技会の準備と組織を担当している。これにはスケジュールの作成、予選リーグの評価方法、競技の進行が含まれている。組織委員会の委員は、ロボカップ評議員会とリーグの実行委員会によって選出される。 +
-The organizing committee of the Small Size League is responsible for preparing and organizing the competition. This mainly includes making the schedule, performing the qualification process, and running the competition. The committee members are selected by the <<Executive Committee, executive committee>> of the league and the RoboCup trustees.
+小型機リーグの組織委員会は競技会の準備と組織を担当している。これにはスケジュールの作成、予選リーグの評価方法、競技の進行が含まれている。組織委員会の委員は、ロボカップ評議員会とリーグの<<実行委員会/Executive Committee,実行委員会>>によって選出される。 +
+The organizing committee of the Small Size League is responsible for preparing and organizing the competition. This mainly includes making the schedule, performing the qualification process, and running the competition. The committee members are selected by the <<実行委員会/Executive Committee, executive committee>> of the league and the RoboCup trustees.
 
 ==== 地域の組織委員会/Local Organizing Committee
 地域の組織委員会は異なるリーグのニーズに応じてイベントを計画して実行する事を担当している。これには、チームエリア（フィールド、ネットワーク、テーブル、ホワイトボード、スクリーンなど）の設営、イベントのスケジュールの作成、安全性とセキュリティのコンセプトの実装が含まれる。 +
@@ -29,11 +29,11 @@ The local organizing committee is responsible for planning and executing the eve
 小型リーグはディヴィジョンAとディヴィジョンBと呼ばれる2つの分けられたトーナメントに分割される。ディヴィジョンAは先進的なチームを対象としており、それ以外の新しいチームや競争力が弱いチームなどはディヴィジョンBで試合をすることができる。各チームは2つのディヴィジョンのうち1つのみに参加することができる。 +
 The Small Size League is divided into two divisions with separate tournaments, namely division A and division B. Division A is aimed at advanced teams whereas new and/or less competitive teams can play in division B. Each team will only play in one of those two divisions.
 
-予選で使う資料を提出する時、各チームは簡潔な理由をつけてどちらのディヴィジョンで競技したいかも選択すること。組織委員会/organizing committeeのメンバーは最終的な決定をする。予選の方法に関する情報はロボカップ小型機リーグの公式ウェブサイト(https://ssl.robocup.org) で確認できる。 +
-When submitting the qualification material, the team also chooses a preferred division including a short rationale. The members of the <<Organizing Committee, organizing committee>> will have the final word. Information about the qualification process can be found on the official RoboCup Small Size League website (https://ssl.robocup.org).
+予選で使う資料を提出する時、各チームは簡潔な理由をつけてどちらのディヴィジョンで競技したいかも選択すること。<<組織委員会/Organizing Committee, 組織委員会>>のメンバーは最終的な決定をする。予選の方法に関する情報はロボカップ小型機リーグの公式ウェブサイト(https://ssl.robocup.org) で確認できる。 +
+When submitting the qualification material, the team also chooses a preferred division including a short rationale. The members of the <<組織委員会/Organizing Committee, organizing committee>> will have the final word. Information about the qualification process can be found on the official RoboCup Small Size League website (https://ssl.robocup.org).
 
-二つのディビジョンの違いに関する要約は付録/Appendixで確認できる。 +
-A summary of differences between the two divisions can be found in the <<Differences Between Divisions, Appendix>>.
+二つのディビジョンの違いに関する要約は<<ディヴィジョンごとの違い/Differences Between Divisions, 付録>>で確認できる。 +
+A summary of differences between the two divisions can be found in the <<ディヴィジョンごとの違い/Differences Between Divisions, Appendix>>.
 
 NOTE: ディヴィジョン制を導入することによって、新しいチームの参入障壁を大幅に引き上げることなく、小型機リーグのより急速な進歩を可能にする。また、ディビジョンの導入によって、同じ強さのチームとの試合を大幅に増やすことができる。 +
 Divisions allow for more radical advancements in the Small Size League without drastically raising the entry barrier for new teams. Additionally, they also considerably increase the amount of matches between teams of similar skill.

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -1,6 +1,6 @@
 == リーグ概要/League Overview
 === 委員会/Committees
-(ロボカップの他のリークと同じように)小型機リーグは3つの異なる委員会(<<実行委員会/Executive Committee, 実行委員会>>、<<技術委員会/Technical Committee, 技術委員会>>、<<組織委員会/Organizing Committee, 組織委員会>>)で運営されている。これらの委員会はそれぞれ異なる責任を持っている。各委員会の委員はロボカップ小型機リーグの公式ウェブサイト(https://ssl.robocup.org) で確認できる。 +
+(ロボカップの他のリークと同じように)小型機リーグは3つの異なる委員会(<<実行委員会/Executive Committee, 実行委員会>>、<<技術委員会/Technical Committee, 技術委員会>>、<<組織委員会/Organizing Committee, 組織委員会>>)で運営されている。これらの委員会はそれぞれ異なる責任を負う。各委員会の委員はロボカップ小型機リーグの公式ウェブサイト(https://ssl.robocup.org) で確認できる。 +
 The Small Size League (like every other league of the RoboCup) is run by close cooperation of three different committees (<<実行委員会/Executive Committee, executive committee>>, <<技術委員会/Technical Committee, technical committee>> and <<組織委員会/Organizing Committee, organizing committee>>), all with a different set of responsibilities. The members of the respective committees can be found on the official RoboCup Small Size League website (https://ssl.robocup.org).
 
 NOTE: 実際には、<<技術委員会/Technical Committee, 技術委員会>>と<<組織委員会/Organizing Committee, 組織委員会>>に厳密な区別はない。各委員会の委員が協力して業務をこなしている。 +
@@ -37,5 +37,5 @@ When submitting the qualification material, the team also chooses a preferred di
 二つのディビジョンの違いに関する要約は<<ディヴィジョンごとの違い/Differences Between Divisions, 付録>>で確認できる。 +
 A summary of differences between the two divisions can be found in the <<ディヴィジョンごとの違い/Differences Between Divisions, Appendix>>.
 
-NOTE: ディヴィジョン制を導入することによって、新しいチームの参入障壁を大幅に引き上げることなく、小型機リーグのより急速な進歩を可能にする。また、ディビジョンの導入によって、同じ強さのチームとの試合を大幅に増やすことができる。 +
+NOTE: ディヴィジョン制を導入することによって、新しいチームの参入障壁を大幅に引き上げることなく、小型機リーグのより急速な進歩を可能にする。また、ディビジョンの導入によって、同じような強さのチームとの試合を大幅に増やすことができる。 +
 Divisions allow for more radical advancements in the Small Size League without drastically raising the entry barrier for new teams. Additionally, they also considerably increase the amount of matches between teams of similar skill.

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -18,7 +18,7 @@ Executive committee members are responsible for the long term goals of the Small
 The technical committee of the Small Size League is responsible for the technical aspects of the RoboCup, such as maintaining the rules and the shared software. All members are elected by the team leaders of the teams which have participated in the previous competition.
 
 ==== 組織委員会/Organizing Committee
-小型機リーグの組織委員会は競技会の準備と組織を担当している。これにはスケジュールの作成、予選リーグの評価方法、競技の進行が含まれている。技術委員会の委員は、ロボカップ評議員会とリーグの実行委員会によって選出される。 +
+小型機リーグの組織委員会は競技会の準備と組織を担当している。これにはスケジュールの作成、予選リーグの評価方法、競技の進行が含まれている。組織委員会の委員は、ロボカップ評議員会とリーグの実行委員会によって選出される。 +
 The organizing committee of the Small Size League is responsible for preparing and organizing the competition. This mainly includes making the schedule, performing the qualification process, and running the competition. The committee members are selected by the <<Executive Committee, executive committee>> of the league and the RoboCup trustees.
 
 ==== 地域の組織委員会/Local Organizing Committee

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -18,8 +18,10 @@ Executive committee members are responsible for the long term goals of the Small
 The technical committee of the Small Size League is responsible for the technical aspects of the RoboCup, such as maintaining the rules and the shared software. All members are elected by the team leaders of the teams which have participated in the previous competition.
 
 ==== 組織委員会/Organizing Committee
-小型機リーグの組織委員会は競技会の準備と組織を担当している。これにはスケジュールの作成、予選リーグの評価方法、競技の進行が含まれている。組織委員会の委員は、ロボカップ評議員会とリーグの<<実行委員会/Executive Committee,実行委員会>>によって選出される。 +
+小型機リーグの組織委員会は競技会の準備と組織を担当している。これにはスケジュールの作成、出場資格審査、競技の進行が含まれている。組織委員会の委員は、ロボカップ評議員会とリーグの<<実行委員会/Executive Committee,実行委員会>>によって選出される。 +
 The organizing committee of the Small Size League is responsible for preparing and organizing the competition. This mainly includes making the schedule, performing the qualification process, and running the competition. The committee members are selected by the <<実行委員会/Executive Committee, executive committee>> of the league and the RoboCup trustees.
+
+NOTE: "Qualification Process"(出場資格審査)は参加予定チームによるTeam Description Paper(TDP)ならびに評価用ビデオの提出、匿名での他チーム評価(要求された場合は加筆訂正のうえ再提出)からなる一連のプロセスを指し、世界大会出場のための前提条件となる。
 
 ==== 地域の組織委員会/Local Organizing Committee
 地域の組織委員会は異なるリーグのニーズに応じてイベントを計画して実行する事を担当している。これには、チームエリア（フィールド、ネットワーク、テーブル、ホワイトボード、スクリーンなど）の設営、イベントのスケジュールの作成、安全性とセキュリティのコンセプトの実装が含まれる。 +
@@ -29,7 +31,7 @@ The local organizing committee is responsible for planning and executing the eve
 小型リーグはディヴィジョンAとディヴィジョンBと呼ばれる2つの分けられたトーナメントに分割される。ディヴィジョンAは先進的なチームを対象としており、それ以外の新しいチームや競争力が弱いチームなどはディヴィジョンBで試合をすることができる。各チームは2つのディヴィジョンのうち1つのみに参加することができる。 +
 The Small Size League is divided into two divisions with separate tournaments, namely division A and division B. Division A is aimed at advanced teams whereas new and/or less competitive teams can play in division B. Each team will only play in one of those two divisions.
 
-予選で使う資料を提出する時、各チームは簡潔な理由をつけてどちらのディヴィジョンで競技したいかも選択すること。<<組織委員会/Organizing Committee, 組織委員会>>のメンバーは最終的な決定をする。予選の方法に関する情報はロボカップ小型機リーグの公式ウェブサイト(https://ssl.robocup.org) で確認できる。 +
+出場資格審査で使う資料を提出する時、各チームは簡潔な理由をつけてどちらのディヴィジョンで競技したいかも選択すること。<<組織委員会/Organizing Committee, 組織委員会>>のメンバーは最終的な決定をする。出場資格審査の方法に関する情報はロボカップ小型機リーグの公式ウェブサイト(https://ssl.robocup.org) で確認できる。 +
 When submitting the qualification material, the team also chooses a preferred division including a short rationale. The members of the <<組織委員会/Organizing Committee, organizing committee>> will have the final word. Information about the qualification process can be found on the official RoboCup Small Size League website (https://ssl.robocup.org).
 
 二つのディビジョンの違いに関する要約は<<ディヴィジョンごとの違い/Differences Between Divisions, 付録>>で確認できる。 +

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -16,7 +16,7 @@ All minor offenses are listed below.
 ロボットがボールに触れた後、ミッドラインを通過してさらに別のロボットに触れずにゴール以外のゴールラインを通過した時、そのキックは無意味である。キックオフをするためのキックはボールはミッドラインに位置しているのでミッドラインを交差していない扱いとなり、そのため無エイムレスキックではない。 +
 A kick is aimless when after the ball touched a robot, it subsequently crossed the midline and then its opponent's goal line outside the goal without touching another robot. A kick-off kick cannot be aimless, as the ball is located at the midline and does therefore not cross it.
 
-NOTE: (訳者注)一般的に「エイムレスキック」、もしくはルールを参考にした競技であるアイスホッケーに由来して「アイシング」と呼称されることが多い。
+NOTE: (訳者注)一般的に「エイムレスキック」と呼称されるが、ルールを参考にした競技であるアイスホッケーに由来して「アイシング」、さらにそれを解釈して(ロボカップがカーペット上で行われることから)「カーペティング」などと呼称されることもある。
 
 ==== 進行の欠落/Lack Of Progress
 1チームだけが<<ボールの操作/Ball Manipulation, ボールを操作する>>ことが許可されている(<<キックオフ/Kick-Off, キックオフ>>、<<直接フリーキック/Direct Free Kick, 直接フリーキック>>、<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>、<<ペナルティーキック/Penalty Kick, ペナルティーキック>>)時に、ボールを動かして試合をインプレイに変化させない場合、進行の欠落が発生している。制限時間はディヴィジョンAの<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>と<<直接フリーキック/Direct Free Kick, 直接フリーキック>>が5秒、それ以外は10秒である。 +

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -6,7 +6,7 @@ NOTE: 経験則:軽微な違反はボールが<<インプレイとアウトオ�
 Rule of thumb: Minor offenses are infringements of the rules committed by an attacking robot while the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>. Fouls are infringements of the rules committed by a defender or while the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>> or infringements that may harm the humans, the robots or the field.
 
 === 軽微な違反/Minor Offenses
-軽微な違反はルール違反となり、結果として試合の停止とその後の相手チームへの<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>となる。フリーキックは違反が発生した場所から蹴られる(正確なボールの位置に関するルールは「<<直接フリーキック/Direct Free Kick, 直接フリーキック>>」を参照する事。 +
+軽微な違反はルール違反となり、結果として試合の停止とその後の相手チームへの<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>となる。フリーキックは違反が発生した場所から蹴られる(正確なボールの位置に関するルールは「<<直接フリーキック/Direct Free Kick, 直接フリーキック>>」を参照する事)。 +
 Minor offenses are violations of the rules that result in a stoppage and a subsequent <<間接フリーキック/Indirect Free Kick, indirect free kick>> for the opposing team. The free kick will be shot from the position where the offense began happening (see <<直接フリーキック/Direct Free Kick, the direct free kick rules>> for the exact ball position rules).
 
 軽微な違反を以下に示す +
@@ -28,7 +28,7 @@ There is also a lack of progress if the ball is inside a team's <<ディフェ�
 NOTE: もし両チームともボールを操作してよい状態で、チームが違反をしていないのであれば、主審は試合を停止し、<<フォーススタート/Force Start, force start>>コマンドを発行することができる。 +
 If both teams are allowed to manipulate the ball, and thus no team is at fault, the referee may stop the game and issue a <<フォーススタート/Force Start, force start>> command.
 
-NOTE: 両チームともルール違反をせずにボールを<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>にする事が明らかにできない場合、主審は相手チームの、<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>の代わりに<<フォーススタート/Force Start, force start>>コマンドを発行することができる。 +
+NOTE: 両チームともルール違反をせずにボールを<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>にする事が明らかにできない場合、主審は相手チームの<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>の代わりに<<フォーススタート/Force Start, force start>>コマンドを発行することができる。 +
 If both teams are clearly unable to bring the ball <<インプレイとアウトオブプレイ/Ball In And Out Of Play, into play>> without violating the rules, the referee may issue a <<フォーススタート/Force Start, force start>> command instead of an <<間接フリーキック/Indirect Free Kick, indirect free kick>> for the other team.
 
 ==== ダブルタッチ/Double Touch
@@ -83,7 +83,7 @@ NOTE: ボールが試合の停止中の場合、より厳密なルールであ�
 When the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>>, the rule <<ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area, Robot Too Close To Opponent Defense Area>> applies instead.
 
 ==== ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area
-ボールが<<試合の再開/Resuming The Game, 試合の再開>>に入る前の、<<停止/Stop, 停止>>、<<直接フリーキック/Direct Free Kick, 直接フリーキック>>、<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>の間、すべてのロボットは相手の<<ディフェンスエリア/Defense Area, ディフェンスエリア>>から少なくとも0.2m以上離れていなければならない。 +
+<<試合の再開/Resuming The Game, 試合を再開する>>前の、<<停止/Stop, 停止>>、<<直接フリーキック/Direct Free Kick, 直接フリーキック>>、<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>の間、すべてのロボットは相手の<<ディフェンスエリア/Defense Area, ディフェンスエリア>>から少なくとも0.2m以上離れていなければならない。 +
 During <<停止/Stop, stop>>, <<直接フリーキック/Direct Free Kick, direct free kicks>> and <<間接フリーキック/Indirect Free Kick, indirect free kicks>>, before the ball <<試合の再開/Resuming The Game, has entered play>>, all robots have to keep at least 0.2 meters distance to the opponent <<ディフェンスエリア/Defense Area, defense area>>.
 
 ロボットが相手のディフェンスエリアから離れるのに2秒の猶予期間がある。 +

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -13,7 +13,7 @@ Minor offenses are violations of the rules that result in a stoppage and a subse
 All minor offenses are listed below.
 
 ==== エイムレスキック/Aimless Kick [small]#(_division B only_)#
-ロボットがボールに触れた後、ミッドラインを通過してさらに別のロボットに触れずにゴール以外のゴールラインを通過した時、そのキックは無意味である。キックオフをするためのキックはボールはミッドラインに位置しているのでミッドラインを交差していない扱いとなり、そのため無意味なキックではない。 +
+ロボットがボールに触れた後、ミッドラインを通過してさらに別のロボットに触れずにゴール以外のゴールラインを通過した時、そのキックは無意味である。キックオフをするためのキックはボールはミッドラインに位置しているのでミッドラインを交差していない扱いとなり、そのため無エイムレスキックではない。 +
 A kick is aimless when after the ball touched a robot, it subsequently crossed the midline and then its opponent's goal line outside the goal without touching another robot. A kick-off kick cannot be aimless, as the ball is located at the midline and does therefore not cross it.
 
 NOTE: (訳者注)一般的に「エイムレスキック」、もしくはルールを参考にした競技であるアイスホッケーに由来して「アイシング」と呼称されることが多い。

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -41,7 +41,7 @@ The ball must have moved at least 0.05 meters to be considered as <<インプレ
 NOTE: キックを行おうとしている間に、ロボットが短い距離でボールを跳ねさせてしまう事がありうることが理解される。そこで、ロボットがルールに違反しているかどうかの判定に0.05mの距離が使用される。技術的にロボットが一度しかボールに触れていなかったとしても、0.05m以上ボールと接触し続けた場合は、ダブルタッチとみなされる。 +
 It is understood that the ball may be bumped by the robot multiple times over a short distance while the kick is being taken. This is why a distance of 0.05 meters is used to decide whether a robot violates this rule or not. Remaining in contact with the ball for more than 0.05 meters also counts as double touch, even though technically the robot only touched the ball once.
 
-==== ディフェンスエリアにあるアタッカー/Attacker In Defense Area
+==== アタッカーの相手ディフェンスエリアへの侵入/Attacker In Defense Area
 相手の<<ディフェンスエリア/Defense Area, ディフェンスエリア>>に部分的もしくは完全に入っている場合、ロボットはボールに触れてはいけない。 +
 A robot must not touch the ball while being partially or fully inside the opponent <<ディフェンスエリア/Defense Area, defense area>>.
 

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -1,13 +1,13 @@
 == 反則/Offenses
-反則は反則の深刻さに応じて複数のカテゴリに分類される。：軽微な違反、ファウル、非スポーツマン行為 +
-Offenses are divided into multiple categories according to the seriousness of the offense: <<Minor Offenses, minor offenses>>, <<Fouls, fouls>> and <<Unsporting Behavior, unsporting behavior>>.
+反則は反則の深刻さに応じて複数のカテゴリに分類される。：<<軽微な違反/Minor Offenses, 軽微な違反>>、<<ファウル/Fouls, ファウル>>、<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>> +
+Offenses are divided into multiple categories according to the seriousness of the offense: <<軽微な違反/Minor Offenses, minor offenses>>, <<ファウル/Fouls, fouls>> and <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>.
 
-NOTE: 経験則:軽微な違反はボールがインプレイの間に攻撃側ロボットがルール違反を犯す事である。ファウルは守備側ロボットがルール違反を犯したか、アウトオブプレイの間か、人間・ロボット・フィールドに危害を加える可能性のある違反である。 +
-Rule of thumb: Minor offenses are infringements of the rules committed by an attacking robot while the ball is <<Ball In And Out Of Play, in play>>. Fouls are infringements of the rules committed by a defender or while the ball is <<Ball In And Out Of Play, out of play>> or infringements that may harm the humans, the robots or the field.
+NOTE: 経験則:軽微な違反はボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>の間に攻撃側ロボットがルール違反を犯す事である。ファウルは守備側ロボットがルール違反を犯したか、<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>の間か、人間・ロボット・フィールドに危害を加える可能性のある違反である。 +
+Rule of thumb: Minor offenses are infringements of the rules committed by an attacking robot while the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>. Fouls are infringements of the rules committed by a defender or while the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>> or infringements that may harm the humans, the robots or the field.
 
 === 軽微な違反/Minor Offenses
-軽微な違反はルール違反となり、結果として試合の停止とその後の相手チームへの間接フリーキックとなる。フリーキックは違反が発生した場所から蹴られる(正確なボールの位置に関するルールは直接フリーキックを参照する事。 +
-Minor offenses are violations of the rules that result in a stoppage and a subsequent <<Indirect Free Kick, indirect free kick>> for the opposing team. The free kick will be shot from the position where the offense began happening (see <<Direct Free Kick, the direct free kick rules>> for the exact ball position rules).
+軽微な違反はルール違反となり、結果として試合の停止とその後の相手チームへの<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>となる。フリーキックは違反が発生した場所から蹴られる(正確なボールの位置に関するルールは「<<直接フリーキック/Direct Free Kick, 直接フリーキック>>」を参照する事。 +
+Minor offenses are violations of the rules that result in a stoppage and a subsequent <<間接フリーキック/Indirect Free Kick, indirect free kick>> for the opposing team. The free kick will be shot from the position where the offense began happening (see <<直接フリーキック/Direct Free Kick, the direct free kick rules>> for the exact ball position rules).
 
 軽微な違反を以下に示す +
 All minor offenses are listed below.
@@ -19,39 +19,39 @@ A kick is aimless when after the ball touched a robot, it subsequently crossed t
 NOTE: (訳者注)一般的に「エイムレスキック」、もしくはルールを参考にした競技であるアイスホッケーに由来して「アイシング」と呼称されることが多い。
 
 ==== 進行の欠落/Lack Of Progress
-1チームだけがボールを操作することが許可されている(キックオフ、直接フリーキック、間接フリーキック、ペナルティーキック)時に、ボールを動かして試合をインプレイに変化させない場合、進行の欠落が発生している。制限時間はディヴィジョンAの間接フリーキックと直接フリーキックが5秒、それ以外は10秒である。 +
-There is a lack of progress if only one team is allowed to <<Ball Manipulation, manipulate the ball>> (<<Kick-Off, kick-off>>, <<Direct Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free kick>>, <<Penalty Kick, penalty kick>>) and does not bring the ball <<Ball In And Out Of Play, into play>> in time. The time limit is 5 seconds for <<Indirect Free Kick, indirect free kicks>> and <<Direct Free Kick, direct free kicks>> in division A and 10 seconds in all other cases.
+1チームだけが<<ボールの操作/Ball Manipulation, ボールを操作する>>ことが許可されている(<<キックオフ/Kick-Off, キックオフ>>、<<直接フリーキック/Direct Free Kick, 直接フリーキック>>、<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>、<<ペナルティーキック/Penalty Kick, ペナルティーキック>>)時に、ボールを動かして試合をインプレイに変化させない場合、進行の欠落が発生している。制限時間はディヴィジョンAの<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>と<<直接フリーキック/Direct Free Kick, 直接フリーキック>>が5秒、それ以外は10秒である。 +
+There is a lack of progress if only one team is allowed to <<ボールの操作/Ball Manipulation, manipulate the ball>> (<<キックオフ/Kick-Off, kick-off>>, <<直接フリーキック/Direct Free Kick, direct free kick>>, <<間接フリーキック/Indirect Free Kick, indirect free kick>>, <<ペナルティーキック/Penalty Kick, penalty kick>>) and does not bring the ball <<インプレイとアウトオブプレイ/Ball In And Out Of Play, into play>> in time. The time limit is 5 seconds for <<間接フリーキック/Indirect Free Kick, indirect free kicks>> and <<直接フリーキック/Direct Free Kick, direct free kicks>> in division A and 10 seconds in all other cases.
 
-また、ボールがどちらかのチームのディフェンスエリアに入っている場合、ゴールキーパーだけがボールを操作してよいロボットなので、10秒間たてば進行の欠落となる。 +
-There is also a lack of progress if the ball is inside a team's <<Defense Area, defense area>> for 10 seconds, since the keeper is the only robot that is allowed to <<Ball Manipulation, manipulate the ball>>.
+また、ボールがどちらかのチームの<<ディフェンスエリア/Defense Area, ディフェンスエリア>>に入っている場合、ゴールキーパーだけが<<ボールの操作/Ball Manipulation, ボールを操作>>してよいロボットなので、10秒間たてば進行の欠落となる。 +
+There is also a lack of progress if the ball is inside a team's <<ディフェンスエリア/Defense Area, defense area>> for 10 seconds, since the keeper is the only robot that is allowed to <<ボールの操作/Ball Manipulation, manipulate the ball>>.
 
-NOTE: もし両チームともボールを操作してよい状態で、チームが違反をしていないのであれば、主審は試合を停止し、force startコマンドを発行することができる。 +
-If both teams are allowed to manipulate the ball, and thus no team is at fault, the referee may stop the game and issue a <<Force Start, force start>> command.
+NOTE: もし両チームともボールを操作してよい状態で、チームが違反をしていないのであれば、主審は試合を停止し、<<フォーススタート/Force Start, force start>>コマンドを発行することができる。 +
+If both teams are allowed to manipulate the ball, and thus no team is at fault, the referee may stop the game and issue a <<フォーススタート/Force Start, force start>> command.
 
-NOTE: 両チームともルール違反をせずにボールをインプレイにする事が明らかにできない場合、主審は相手チームの、間接フリーキックの代わりにforce startコマンドを発行することができる。 +
-If both teams are clearly unable to bring the ball <<Ball In And Out Of Play, into play>> without violating the rules, the referee may issue a <<Force Start, force start>> command instead of an <<Indirect Free Kick, indirect free kick>> for the other team.
+NOTE: 両チームともルール違反をせずにボールを<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>にする事が明らかにできない場合、主審は相手チームの、<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>の代わりに<<フォーススタート/Force Start, force start>>コマンドを発行することができる。 +
+If both teams are clearly unable to bring the ball <<インプレイとアウトオブプレイ/Ball In And Out Of Play, into play>> without violating the rules, the referee may issue a <<フォーススタート/Force Start, force start>> command instead of an <<間接フリーキック/Indirect Free Kick, indirect free kick>> for the other team.
 
 ==== ダブルタッチ/Double Touch
-キックオフ、直接フリーキック、間接フリーキック、ペナルティーキックによってボールがインプレイに持ち込まれたとき、キッカーは他のロボットが触れるか、試合が停止するまでボールに触れてはいけない。 +
-When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free kick>> or <<Penalty Kick, penalty kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.
+<<キックオフ/Kick-Off, キックオフ>>、<<直接フリーキック/Direct Free Kick, 直接フリーキック>>、<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>、<<ペナルティーキック/Penalty Kick, ペナルティーキック>>によってボールがインプレイに持ち込まれたとき、キッカーは他のロボットが触れるか、試合が停止するまでボールに触れてはいけない。 +
+When the ball is brought <<インプレイとアウトオブプレイ/Ball In And Out Of Play, into play>> following a <<キックオフ/Kick-Off, kick-off>>, <<直接フリーキック/Direct Free Kick, direct free kick>>, <<間接フリーキック/Indirect Free Kick, indirect free kick>> or <<ペナルティーキック/Penalty Kick, penalty kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.
 
-インプレイになったとみなされるには、少なくとも0.05m以上ボールが動いていなければいけない。 +
-The ball must have moved at least 0.05 meters to be considered as <<Ball In And Out Of Play, in play>>.
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>になったとみなされるには、少なくとも0.05m以上ボールが動いていなければいけない。 +
+The ball must have moved at least 0.05 meters to be considered as <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>.
 
 NOTE: キックを行おうとしている間に、ロボットが短い距離でボールを跳ねさせてしまう事がありうることが理解される。そこで、ロボットがルールに違反しているかどうかの判定に0.05mの距離が使用される。技術的にロボットが一度しかボールに触れていなかったとしても、0.05m以上ボールと接触し続けた場合は、ダブルタッチとみなされる。 +
 It is understood that the ball may be bumped by the robot multiple times over a short distance while the kick is being taken. This is why a distance of 0.05 meters is used to decide whether a robot violates this rule or not. Remaining in contact with the ball for more than 0.05 meters also counts as double touch, even though technically the robot only touched the ball once.
 
 ==== ディフェンスエリアにあるアタッカー/Attacker In Defense Area
-相手のディフェンスエリアに部分的もしくは完全に入っている場合、ロボットはボールに触れてはいけない。 +
-A robot must not touch the ball while being partially or fully inside the opponent <<Defense Area, defense area>>.
+相手の<<ディフェンスエリア/Defense Area, ディフェンスエリア>>に部分的もしくは完全に入っている場合、ロボットはボールに触れてはいけない。 +
+A robot must not touch the ball while being partially or fully inside the opponent <<ディフェンスエリア/Defense Area, defense area>>.
 
-NOTE: ボールが試合の停止中の場合、より厳密なルールであるロボットがディフェンスエリアに近すぎるが適用される。 +
-When the ball is <<Ball In And Out Of Play, out of play>>, the more strict rule <<Robot Too Close To Opponent Defense Area>> applies instead.
+NOTE: ボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, 試合の停止中>>の場合、より厳密なルールである「<<ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area,ロボットの相手ディフェンスエリアへの極端な接近>>」が適用される。 +
+When the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>>, the more strict rule <<ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area, [Robot Too Close To Opponent Defense Area]>> applies instead.
 
 ==== ドリブルの超過/Excessive Dribbling
 
-ロボットはドリブルが開始されたボールの位置から直線距離で測定して1m以上ドリブルしてはいけない。(ドリブルをした距離の測定方法としては)ロボットはボールと接触したときにドリブルを開始し、ボールとロボットの間に視認できるだけの間隔がある場合にドリブルを停止する。
-A robot must not <<Dribbling Device, dribble>> the ball further than 1 meter, measured linearly from the ball location where the dribbling started. A robot begins dribbling when it makes contact with the ball and stops dribbling when there is an observable separation between the ball and the robot.
+ロボットは<<ドリブルデバイス/Dribbling Device, ドリブル>>が開始されたボールの位置から直線距離で測定して1m以上ドリブルしてはいけない。(ドリブルをした距離の測定方法としては)ロボットはボールと接触したときにドリブルを開始し、ボールとロボットの間に視認できるだけの間隔がある場合にドリブルを停止する。
+A robot must not <<ドリブルデバイス/Dribbling Device, dribble>> the ball further than 1 meter, measured linearly from the ball location where the dribbling started. A robot begins dribbling when it makes contact with the ball and stops dribbling when there is an observable separation between the ball and the robot.
 
 NOTE: 人間のサッカー選手が頻繁に行うように、ロボットがボールを前に蹴るなどして定期的にボールの所有権を失う限り、ドリブラー使用して長い距離をドリブルし続けることができる。 +
 Dribblers can still be used to dribble large distances with the ball as long as the robot periodically loses possession, such as kicking the ball ahead of it as human soccer players often do.
@@ -63,42 +63,42 @@ NOTE: (訳者注)一般的に「オーバードリブル」と呼称されるこ
 A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.
 
 === ファウル/Fouls
-ファウルは違反に関するルールで、結果として相手チームに直接フリーキックを与える。そのフリーキックは違反が発生し始めた場所からシュートされる(正確なボールの位置に関するルールは直接フリーキックのルールを参照)。ファウルが試合の停止中に発生した場合、フリーキックは与えられない。 +
-Fouls are violations of the rules that result in a <<Direct Free Kick, direct free kick>> for the opposing team. The free kick will be shot from the position where the offense began happening (see <<Direct Free Kick, the direct free kick rules>> for the exact ball position rules). If the foul happened while the ball is <<Ball In And Out Of Play, out of play>>, no free kick is given.
+ファウルは違反に関するルールで、結果として相手チームに<<直接フリーキック/Direct Free Kick, 直接フリーキック>>を与える。そのフリーキックは違反が発生し始めた場所からシュートされる(正確なボールの位置に関するルールは<<直接フリーキック/Direct Free Kick, 直接フリーキックのルール>>を参照)。ファウルが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, 試合の停止中>>に発生した場合、フリーキックは与えられない。 +
+Fouls are violations of the rules that result in a <<直接フリーキック/Direct Free Kick, direct free kick>> for the opposing team. The free kick will be shot from the position where the offense began happening (see <<直接フリーキック/Direct Free Kick, the direct free kick rules>> for the exact ball position rules). If the foul happened while the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>>, no free kick is given.
 
-同じチームの3回目のファウルごとにイエローカードが出る。 +
-Every third foul of the same team results in a <<Yellow Card, yellow card>>.
+同じチームの3回目のファウルごとに<<イエローカード/Yellow Card, イエローカード>>が出る。 +
+Every third foul of the same team results in a <<イエローカード/Yellow Card, yellow card>>.
 
-重大なファウルの場合、主審はイエローカードかレッドカードを提示できる。 +
-In case of severe fouls, the referee can also issue a <<Yellow Card, yellow card>> or a <<Red Card, red card>>.
+重大なファウルの場合、主審は<<イエローカード/Yellow Card, イエローカード>>か<<レッドカード/Red Card, レッドカード>>を提示できる。 +
+In case of severe fouls, the referee can also issue a <<イエローカード/Yellow Card, yellow card>> or a <<レッドカード/Red Card, red card>>.
 
 すべてのファウルは以下の通りである。 +
 All fouls are listed below.
 
 ==== 相手ディフェンスエリア内におけるアタッカーロボットの相手ロボットへの接触/Attacker Touches Robot In Opponent Defense Area
-インプレイ中に、敵チームのディフェンスエリアでは、ロボットは敵チームのどのロボットに対しても触れてはいけない。 +
-When the ball <<Ball In And Out Of Play, in play>>, a robot must not touch any opponent robot inside the opponent <<Defense Area, defense area>>.
+<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>中に、敵チームの<<ディフェンスエリア/Defense Area, ディフェンスエリア>>では、ロボットは敵チームのどのロボットに対しても触れてはいけない。 +
+When the ball <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, a robot must not touch any opponent robot inside the opponent <<ディフェンスエリア/Defense Area, defense area>>.
 
-NOTE: ボールが試合の停止中の場合、より厳密なルールであるロボットがディフェンスエリアに近すぎるが適用される。 +
-When the ball is <<Ball In And Out Of Play, out of play>>, the rule <<Robot Too Close To Opponent Defense Area>> applies instead.
+NOTE: ボールが試合の停止中の場合、より厳密なルールである「<<ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area, ロボットの相手ディフェンスエリアへの極端な接近>>」が適用される。 +
+When the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>>, the rule <<ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area, Robot Too Close To Opponent Defense Area>> applies instead.
 
 ==== ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area
-ボールが試合の再開に入る前の、停止、直接フリーキック、間接フリーキックの間、すべてのロボットは相手のディフェンスエリアから少なくとも0.2m以上離れていなければならない。 +
-During <<Stop, stop>>, <<Direct Free Kick, direct free kicks>> and <<Indirect Free Kick, indirect free kicks>>, before the ball <<Resuming The Game, has entered play>>, all robots have to keep at least 0.2 meters distance to the opponent <<Defense Area, defense area>>.
+ボールが<<試合の再開/Resuming The Game, 試合の再開>>に入る前の、<<停止/Stop, 停止>>、<<直接フリーキック/Direct Free Kick, 直接フリーキック>>、<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>の間、すべてのロボットは相手の<<ディフェンスエリア/Defense Area, ディフェンスエリア>>から少なくとも0.2m以上離れていなければならない。 +
+During <<停止/Stop, stop>>, <<直接フリーキック/Direct Free Kick, direct free kicks>> and <<間接フリーキック/Indirect Free Kick, indirect free kicks>>, before the ball <<試合の再開/Resuming The Game, has entered play>>, all robots have to keep at least 0.2 meters distance to the opponent <<ディフェンスエリア/Defense Area, defense area>>.
 
 ロボットが相手のディフェンスエリアから離れるのに2秒の猶予期間がある。 +
 There is a grace period of 2 seconds for the robots to move away from the opponent defense area.
 
 ==== ボール配置への干渉/Ball Placement Interference
-ボール配置の間、配置を担当しないチームのすべてのロボットはボールと配置位置の間のラインから少なくとも0.5mは離れなければならない(この領域はスタジアム状の形になる)。 +
-During <<Ball Placement, ball placement>>, all robots of the non-placing team have to keep at least 0.5 meters distance to the line between the ball and the placement position (the forbidden area forms a stadium shape).
+<<ボール配置/Ball Placement, ボール配置>>の間、配置を担当しないチームのすべてのロボットはボールと配置位置の間のラインから少なくとも0.5mは離れなければならない(この領域はスタジアム状の形になる)。 +
+During <<ボール配置/Ball Placement, ball placement>>, all robots of the non-placing team have to keep at least 0.5 meters distance to the line between the ball and the placement position (the forbidden area forms a stadium shape).
 
 ボール配置を担当しないチームがボールと配置位置の間のラインに2秒以上近づいている場合、ファウルが与えられる。この場合、ボール配置の手順は再スタートする。
 If a robot of the non-placing team is too close to the line between the ball and the placement position for more than 2 seconds, it commits a foul.
 In this case, the placement procedure is restarted.
 
-NOTE: このルールは、ボール配置への干渉をすべてカバーするものではない。主審はボール配置を担当しないチームが明らかにボール配置に干渉している場合は、ファウルを宣告することが推奨される。 +
-This rule does not cover all cases of ball placement interference. The <<Referee, referee>> is encouraged to call fouls if the non-placing team is obviously interfering with the ball placement.
+NOTE: このルールは、ボール配置への干渉をすべてカバーするものではない。<<主審/Referee, 主審>>はボール配置を担当しないチームが明らかにボール配置に干渉している場合は、ファウルを宣告することが推奨される。 +
+This rule does not cover all cases of ball placement interference. The <<主審/Referee, referee>> is encouraged to call fouls if the non-placing team is obviously interfering with the ball placement.
 
 ==== 衝突/Crashing
 異なるチームの2つのロボットの衝突の瞬間に、両方のロボットの速度ベクトルの差が取られ、両方のロボットの位置によって定義される線上に投影される。この投影の長さが1.5m/sを超えると、より速いロボットにファウルを与える。ロボットの絶対速度の差が0.3m./s未満であれば、どちらもファウルを与えるが、ゲームは停止しない。 +
@@ -121,50 +121,50 @@ NOTE: (訳者注)一般的に「ホールディング」と呼称されること
 ロボットは他のロボットに潜在的な脅威を与えるように、フィールドで転倒したり、部品を脱落させてはならない。 +
 A robot must not tip over, break or drop parts on the field that pose a potential threat to other robots.
 
-ロボットがこのルールに違反した場合、ロボットの交代を行わなければならない。 +
-A robot violating this rule has to be <<Robot Substitution, substituted>>.
+ロボットがこのルールに違反した場合、<<ロボットの交代/Robot Substitution, ロボットの交代>>を行わなければならない。 +
+A robot violating this rule has to be <<ロボットの交代/Robot Substitution, substituted>>.
 
 NOTE: (例えばねじなどの)金属パーツと大きな部品は一般的に潜在的に脅威をもたらし、非常に小さい(例えば小車輪のゴムなどの)非金属のパーツはそうではない。 +
 Metal parts (screws for example) as well as larger parts generally pose a potential threat, very small non-metal parts (for example rubber subwheel rings) don't.
 
 ==== ストップ中のロボットの速度/Robot Stop Speed
-ロボットはstop中は1.5m/s以上で動いてはいけない。このルールの反則はストップゲーム1回につき1台のロボットに対してカウントされる。 +
-A robot must not move faster than 1.5 meters per second during <<Stop, stop>>. A violation of this rule is only counted once per robot and stoppage.
+ロボットはstop中は1.5m/s以上で動いてはいけない。このルールの反則は<<停止/Stop, ストップゲーム>>1回につき1台のロボットに対してカウントされる。 +
+A robot must not move faster than 1.5 meters per second during <<停止/Stop, stop>>. A violation of this rule is only counted once per robot and stoppage.
 
 ロボットが減速する猶予時間は2秒である。 +
 There is a grace period of 2 seconds for the robots to slow down.
 
-NOTE: このルールはボール配置には適用されない。 +
-This rule does not apply to <<Ball Placement, ball placement>>.
+NOTE: このルールは<<ボール配置/Ball Placement, ボール配置>>には適用されない。 +
+This rule does not apply to <<ボール配置/Ball Placement, ball placement>>.
 
-NOTE: ロボットの速度制限の意図は、Stopコマンドが手動のボール配置とロボットの交代に使用されるため、ロボットがフィールド内にいる人間の怪我を防ぐためである。 +
-Since the stop command is used for manual ball placement and <<Robot Substitution, robot substitution>>, the intention of the robot speed limit is to avoid robots harming the people on the field.
+NOTE: ロボットの速度制限の意図は、Stopコマンドが手動のボール配置と<<ロボットの交代/Robot Substitution, ロボットの交代>>に使用されるため、ロボットがフィールド内にいる人間の怪我を防ぐためである。 +
+Since the stop command is used for manual ball placement and <<ロボットの交代/Robot Substitution, robot substitution>>, the intention of the robot speed limit is to avoid robots harming the people on the field.
 
 ==== ディフェンダーのボールへの極端な接近/Defender Too Close To Ball
-相手チームのキックオフ、直接フリーキック、間接フリーキックの間、ロボットはボールから少なくとも0.5m以上離れなければならない。ファウルの前に発行されたコマンドと同じコマンドで試合が再開される。 +
-A robot's distance to the ball must be at least 0.5 meters during an opponent <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free kick>> or <<Indirect Free Kick, indirect free kick>>.
+相手チームの<<キックオフ/Kick-Off,  キックオフ>>、<<直接フリーキック/Direct Free Kick, 直接フリーキック>>、<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>の間、ロボットはボールから少なくとも0.5m以上離れなければならない。ファウルの前に発行されたコマンドと同じコマンドで試合が再開される。 +
+A robot's distance to the ball must be at least 0.5 meters during an opponent <<キックオフ/Kick-Off, kick-off>>, <<直接フリーキック/Direct Free Kick, direct free kick>> or <<間接フリーキック/Indirect Free Kick, indirect free kick>>.
 The game is resumed with the same command that was issued before the foul.
 
-NOTE: stop中は、ボールに近すぎる事に対する自動的な罰則はない。主審はチームが必要な距離を守っていない場合、イエローカードを発行することで非スポーツマン行為を罰することができる。詳しい説明は停止を参照する事。 +
-During <<Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>> if it does not respect the required distance. See <<Stop, stop>> for further explanation.
+NOTE: <<停止/Stop, stop>>中は、ボールに近すぎる事に対する自動的な罰則はない。主審はチームが必要な距離を守っていない場合、<<イエローカード/Yellow Card, イエローカード>>を発行することで非スポーツマン行為を罰することができる。詳しい説明は「<<停止/Stop, 停止>>」を参照する事。 +
+During <<停止/Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<非スポーツマン行為/Unsporting Behavior,unsporting behavior>> by issuing a <<イエローカード/Yellow Card, yellow card>> if it does not respect the required distance. See <<停止/Stop, stop>> for further explanation.
 
 ==== マルチプルディフェンス/Multiple Defenders
-NOTE: このルールはファウルに対して定義された標準的な罰則を使用しない。 +
-This rule does not use the standard sanctions defined for <<Fouls, fouls>>.
+NOTE: このルールは<<ファウル/Fouls,　ファウル>>に対して定義された標準的な罰則を使用しない。 +
+This rule does not use the standard sanctions defined for <<ファウル/Fouls, fouls>>.
 
-キーパー以外のロボットが自チームのディフェンスエリアに部分的に入った状態でボールに触れた場合、試合は中断される。そしてロボットはイエローカードを受け取り、相手チームの直接フリーキックで試合を再開する。ファウルのカウンターは増加しない。 +
-If a robot other than the keeper touches the ball while being partially inside its own defense area, the game is stopped, the robot receives a <<Yellow Card, yellow card>> and the opponent team resumes the game with a <<Direct Free Kick, direct free kick>>. The foul counter is not increased.
+キーパー以外のロボットが自チームのディフェンスエリアに部分的に入った状態でボールに触れた場合、試合は中断される。そしてロボットは<<イエローカード/Yellow Card, イエローカード>>を受け取り、相手チームの<<直接フリーキック/Direct Free Kick, 直接フリーキック>>で試合を再開する。ファウルのカウンターは増加しない。 +
+If a robot other than the keeper touches the ball while being partially inside its own defense area, the game is stopped, the robot receives a <<イエローカード/Yellow Card, yellow card>> and the opponent team resumes the game with a <<直接フリーキック/Direct Free Kick, direct free kick>>. The foul counter is not increased.
 
-キーパー以外のロボットが自チームのディフェンスエリアに完全に入った状態でボールに触れた場合、試合は中断される。そして相手チームのペナルティキックで試合を再開する。ファウルのカウンターは増加しない。 +
-If a robot other than the keeper touches the ball while being entirely inside its own defense area, the game is stopped and a <<Penalty Kick, penalty kick>> is awarded to the other team. The foul counter is not increased.
+キーパー以外のロボットが自チームのディフェンスエリアに完全に入った状態でボールに触れた場合、試合は中断される。そして相手チームの<<ペナルティーキック/Penalty Kick, ペナルティーキック>>で試合を再開する。ファウルのカウンターは増加しない。 +
+If a robot other than the keeper touches the ball while being entirely inside its own defense area, the game is stopped and a <<ペナルティーキック/Penalty Kick, penalty kick>> is awarded to the other team. The foul counter is not increased.
 
 
 === 非スポーツマン行為/Unsporting Behavior
-非スポーツマン行為はイエローカード、レッドカード、ペナルティーキック、強制的な試合放棄、失格につながる可能性がある。人間の主審は反則の重要性に応じて適切な処罰を選択する。 +
-Unsporting behavior can lead to <<Yellow Card, yellow cards>>, <<Red Card, red cards>>, <<Penalty Kick, penalty kicks>>, a <<Forced Forfeit, forced forfeit>> or a <<Disqualification, disqualification>>. The human <<Referee, referee>> chooses an appropriate sanction, depending on the severity of the offense.
+非スポーツマン行為は<<イエローカード/Yellow Card, イエローカード>>、<<レッドカード/Red Card, レッドカード>>、<<ペナルティーキック/Penalty Kick, ペナルティーキック>>、<<強制的な試合放棄/Forced Forfeit, 強制的な試合放棄>>、<<失格/Disqualification, 失格>>につながる可能性がある。人間の主審は反則の重要性に応じて適切な処罰を選択する。 +
+Unsporting behavior can lead to <<イエローカード/Yellow Card, yellow cards>>, <<レッドカード/Red Card, red cards>>, <<ペナルティーキック/Penalty Kick, penalty kicks>>, a <<強制的な試合放棄/Forced Forfeit, forced forfeit>> or a <<失格/Disqualification, disqualification>>. The human <<主審/Referee, referee>> chooses an appropriate sanction, depending on the severity of the offense.
 
-NOTE: 審判は、どの処罰を選択すべきか判断できない場合は、技術委員会または組織委員会のメンバーと協議することができる。 +
-If the referee is not sure which sanction to choose, he may confer with members of the <<Technical Committee, technical committee>> or the <<Organizing Committee, organizing committee>>.
+NOTE: 審判は、どの処罰を選択すべきか判断できない場合は、<<技術委員会/Technical Committee, 技術委員会>>または<<組織委員会/Organizing Committee, 組織委員会>>のメンバーと協議することができる。 +
+If the referee is not sure which sanction to choose, he may confer with members of the <<技術委員会/Technical Committee, technical committee>> or the <<組織委員会/Organizing Committee, organizing committee>>.
 
 非スポーツマン行為のいくつかの例は以下の通りである。 +
 Some examples of unsporting behavior are listed below.
@@ -181,36 +181,36 @@ It is not allowed to damage or modify the field or the ball.
 チームメンバーは試合に関わる全員に対して適切な敬意を示している必要がある。このルールの侵害には以下が含まれるがこれらに限定されない。 +
 A team member must show appropriate respect to everyone involved in the game. Infringements of this rule include but are not limited to:
 
-* 相手、主審またはその他公平な役割の人を侮辱する +
-insulting the opponent, the <<Referee, referee>> or other persons holding an <<Impartial Roles, impartial role>>
-* 主審またはその他公平な役割の人に迷惑をかける +
-annoying the <<Referee, referee>> or other persons holding an <<Impartial Roles, impartial role>>
-* 主審の指示に従わない +
-not obeying the orders of the <<Referee, referee>>
+* 相手、<<主審/Referee, 主審>>またはその他<<公正な役割/Impartial Roles, 公平な役割>>の人を侮辱する +
+insulting the opponent, the <<主審/Referee, referee>> or other persons holding an <<公正な役割/Impartial Roles, impartial role>>
+* <<主審/Referee, 主審>>またはその他<<公正な役割/Impartial Roles, 公平な役割>>の人に迷惑をかける +
+annoying the <<主審/Referee, referee>> or other persons holding an <<公正な役割/Impartial Roles, impartial role>>
+* <<主審/Referee, 主審>>の指示に従わない +
+not obeying the orders of the <<主審/Referee, referee>>
 
 === 同時多発的な反則/Simultaneous Offenses
-試合がstop中かつチームが試合を再開する事を許可されている場合に、相手チームの軽微な違反とファウルは試合の再開方法及び位置には影響しない。ただし再開の方法がペナルティーキックの場合は除く。 +
-If the game is <<Stop, stopped>> and a team is allowed to <<Resuming The Game, resume the game>>, <<Minor Offenses, minor offenses>> and <<Fouls, fouls>> of this team's opponent don't affect the method and position of the resumption of the game, except if the resulting method is a <<Penalty Kick, penalty kick>>.
+試合が<<停止/Stop, stop>>中かつチームが<<試合の再開/Resuming The Game, 試合を再開する>>事を許可されている場合に、相手チームの<<軽微な違反/Minor Offenses, 軽微な違反>>と<<ファウル/Fouls, ファウル>>は試合の再開方法及び位置には影響しない。ただし再開の方法が<<ペナルティーキック/Penalty Kick, ペナルティーキック>>の場合は除く。 +
+If the game is <<停止/Stop, stopped>> and a team is allowed to <<試合の再開/Resuming The Game, resume the game>>, <<軽微な違反/Minor Offenses, minor offenses>> and <<ファウル/Fouls, fouls>> of this team's opponent don't affect the method and position of the resumption of the game, except if the resulting method is a <<ペナルティーキック/Penalty Kick, penalty kick>>.
 
-チームがこのルールを悪用した場合、主審は非スポーツマン行為としてイエローカードで処罰を与えることができる。 +
-If a team exploits this rule, the referee may punish this team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>>.
+チームがこのルールを悪用した場合、主審は<<非スポーツマン行為/Unsporting Behavior,非スポーツマン行為>>として<<イエローカード/Yellow Card, イエローカード>>で処罰を与えることができる。 +
+If a team exploits this rule, the referee may punish this team for <<非スポーツマン行為/Unsporting Behavior,unsporting behavior>> by issuing a <<イエローカード/Yellow Card, yellow card>>.
 
-NOTE: このルールは相手の直接フリーキックと間接フリーキックをより有利な位置に動かすためにチームが意図的に反則をしないようにするために設定されている。 +
-This rule is in place to prevent teams from purposely committing offenses in order to relocate the opponent <<Direct Free Kick, direct free kick>> or <<Indirect Free Kick, indirect free kick>> to a more favorable position.
+NOTE: このルールは相手の<<直接フリーキック/Direct Free Kick, 直接フリーキック>>と<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>をより有利な位置に動かすためにチームが意図的に反則をしないようにするために設定されている。 +
+This rule is in place to prevent teams from purposely committing offenses in order to relocate the opponent <<直接フリーキック/Direct Free Kick, direct free kick>> or <<間接フリーキック/Indirect Free Kick, indirect free kick>> to a more favorable position.
 
 === アドバンテージルール/Advantage Rule
-特定の状況下では、ファウルのために試合を止めることは相手チームに不利益をもたらす可能性がある。これらの状況は自動的に検知する事が難しいので、相手チームは試合を継続したいか確認される。この場合、試合は停止されず直接フリーキックは行われない。ファウルのカウンタは加算され、いかなる結果のカードも試合が停止した段階で与えられる。 +
+特定の状況下では、ファウルのために試合を止めることは相手チームに不利益をもたらす可能性がある。これらの状況は自動的に検知する事が難しいので、相手チームは試合を継続したいか確認される。この場合、試合は停止されず直接フリーキックは行われない。ファウルのカウンタは加算され、いかなる結果のカードも試合が<<停止/Stop, 停止>>した段階で与えられる。 +
 In certain situations, stopping the game because of a foul may have a disadvantage to the opposing team.
 As these situations are not easy to detect automatically, the opposing team is asked if it likes to continue the game.
 In this case, the game is not stopped and no direct kick is awarded at any time.
-The foul counter is still incremented and any resulting cards are given when the game is <<Stop,stopped>>.
+The foul counter is still incremented and any resulting cards are given when the game is <<停止/Stop,stopped>>.
 
 .考慮されるファウル/Fouls that are considered
 
-* 衝突、両方のチームがファウルを犯していない場合 +
-<<Crashing>>, if not both teams committed the foul
-* アタッカーが敵ディフェンスエリアの中でロボットに触れる +
-<<Attacker Touches Robot In Opponent Defense Area>>
+* <<衝突/Crashing, 衝突>>、両方のチームがファウルを犯していない場合 +
+<<衝突/Crashing, Crashing>>, if not both teams committed the foul
+* <<相手ディフェンスエリア内におけるアタッカーロボットの相手ロボットへの接触/Attacker Touches Robot In Opponent Defense Area, 相手ディフェンスエリア内におけるアタッカーロボットの相手ロボットへの接触>> +
+<<相手ディフェンスエリア内におけるアタッカーロボットの相手ロボットへの接触/Attacker Touches Robot In Opponent Defense Area, Attacker Touches Robot In Opponent Defense Area>>
 
 NOTE: チームがgame controloserに接続していない場合や0.2秒以内に応答しない場合、デフォルトでStop Gameを選択したものとみなされる。 +
 If the team is not connected to the game controller or does not reply within 0.2 seconds, the decision of the team defaults to stopping the game.

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -13,7 +13,7 @@ The field of play must be rectangular and of the following size:
 実際のフィールドサイズとフィールドのマーキングは±10％の誤差の範囲内にある。 +
 The exact field dimensions and the field markings at the venue may vary by up to ±10% in each linear dimension.
 
-フィールド、ゴールおよび特別なフィールドエリアの詳細については<<field-dimensions-a, Figure 1>>、<<field-dimensions-b, Figure 2>>を見ること。 +
+以下の２つの図は、フィールド、ゴールおよび特別なフィールドエリアをミリメータで測定した詳細を示している。ディヴィジョンAについては<<field-dimensions-a, Figure 1>>、ディフィジョンBについては<<field-dimensions-b, Figure 2>>を見ること。 +
 The two figures below show the dimensions of the field, the goals and special field areas, measured in millimeters.  <<field-dimensions-a, Figure 1>> shows the dimensions for division A and  <<field-dimensions-b, figure 2>> for division B.
 
 NOTE: 図中の数値はミリメートル表示の距離である +

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -13,7 +13,7 @@ The field of play must be rectangular and of the following size:
 実際のフィールドサイズとフィールドのマーキングは±10％の誤差の範囲内にある。 +
 The exact field dimensions and the field markings at the venue may vary by up to ±10% in each linear dimension.
 
-フィールド、ゴールおよび特別なフィールドエリアの詳細についてはFigure 1、Figure 2を見ること。 +
+フィールド、ゴールおよび特別なフィールドエリアの詳細については<<field-dimensions-a, Figure 1>>、<<field-dimensions-b, Figure 2>>を見ること。 +
 The two figures below show the dimensions of the field, the goals and special field areas, measured in millimeters.  <<field-dimensions-a, Figure 1>> shows the dimensions for division A and  <<field-dimensions-b, figure 2>> for division B.
 
 NOTE: 図中の数値はミリメートル表示の距離である +
@@ -35,8 +35,8 @@ image::lawsofthegame_201819_p35_field.png[]
 競技フィールドの表面は緑色のフェルトマットかカーペットである。カーペット下の床は固く平坦で水平である。 +
 The playing surface is green felt mat or carpet. The floor under the carpet is level, flat, and hard.
 
-フィールドはすべてのフィールドライン/field linesから0.7mまで続いている。フィールドの外周には高さ0.1mのフェンスがあり、ロボットやボールがフィールド外に出ることを防ぐ。フィールドのさらに0.4m外側は主審/refereeと副審/assistant refereeが通行するためのエリアである。 +
-The field surface will continue for 0.7 meters beyond the <<Field Lines, field lines>> on all sides. The outer 0.4 meters of this runoff area, separated from the robot area by a 0.1 meters tall wall, is used as a designated walking area for the <<Referee, referee>> and the <<Assistant Referee, assistant referee>>.
+フィールドはすべての<<フィールドライン/Field Lines, フィールドライン>>から0.7mまで続いている。フィールドの外周には高さ0.1mのフェンスがあり、ロボットやボールがフィールド外に出ることを防ぐ。フィールドのさらに0.4m外側は<<主審/Referee, 主審>>と<<副審/Assistant Referee, 副審>>が通行するためのエリアである。 +
+The field surface will continue for 0.7 meters beyond the <<フィールドライン/Field Lines, field lines>> on all sides. The outer 0.4 meters of this runoff area, separated from the robot area by a 0.1 meters tall wall, is used as a designated walking area for the <<主審/Referee, referee>> and the <<副審/Assistant Referee, assistant referee>>.
 
 
 ==== フィールドのマーキング/Field Markings
@@ -51,7 +51,7 @@ The playing area is defined by four field lines. The two longer field lines are 
 競技フィールドは、フィールド中心からフィールドの両端に引かれているハーフウェーラインによって半分に分割される。ハーフウェーラインはゴールラインと平行である。 +
 The field of play is divided into two halves by a halfway line that runs along the width of the field and through the center of the field. The halfway line is parallel to the goal lines.
 
-ミッドラインはフィールド中心からフィールドの長さ方向に沿って引かれている。ミッドラインはタッチラインと平行である。このラインはvision softwareのジオメトリのキャリブレーションを適切に行うために必要な機能を提供するために使用される。 +
+ミッドラインはフィールド中心からフィールドの長さ方向に沿って引かれている。ミッドラインはタッチラインと平行である。このラインは<<Vision, visionソフトウェア>>のジオメトリのキャリブレーションを適切に行うために必要な機能を提供するために使用される。 +
 A mid-line runs along the length of the field, passing through the center of the field. The mid-line is parallel to the touch lines. This line is used to provide adequate features for the geometry calibration of the <<Vision, vision software>>.
 
 ===== センターサークル/Center Circle
@@ -59,8 +59,8 @@ A mid-line runs along the length of the field, passing through the center of the
 The center mark is indicated at the midpoint of the halfway line. A circle with a diameter of 1 meter is marked around it for both divisions.
 
 ===== ディフェンスエリア/Defense Area
-ディフェンスエリアは中心から見て両端にあるゴール/goalsと接するゴールラインと接する長方形で定義される。ディフェンスエリアの大きさは図1と図2に示される通り、ディヴィジョンAであれば2.4×1.2m、ディヴィジョンBであれば2m×1mである。 +
-A defense area is defined as a rectangle touching the goal lines centrally in front of both <<Goals, goals>>. The size of the defense area is 2.4 meters times 1.2 meters for division A and 2 meters times 1 meter for division B, as shown in figures <<field-dimensions-a, 1>> and <<field-dimensions-b, 2>> respectively.
+ディフェンスエリアは中心から見て両端にある<<ゴール/Goals, ゴール>>と接するゴールラインと接する長方形で定義される。ディフェンスエリアの大きさは<<field-dimensions-a, Figure 1>>と<<field-dimensions-b, Figure 2>>に示される通り、ディヴィジョンAであれば2.4×1.2m、ディヴィジョンBであれば2m×1mである。 +
+A defense area is defined as a rectangle touching the goal lines centrally in front of both <<ゴール/Goals, goals>>. The size of the defense area is 2.4 meters times 1.2 meters for division A and 2 meters times 1 meter for division B, as shown in figures <<field-dimensions-a, 1>> and <<field-dimensions-b, 2>> respectively.
 
 
 ===== ペナルティーマーク/Penalty Mark
@@ -74,7 +74,7 @@ The penaly mark does not need to be painted since it coincides with the intersec
 ゴールはそれぞれのゴールラインの中央に配置し、しっかりと固定されなければいけない。ゴールは高さ0.16mの2枚の垂直なサイドウォールと1枚の垂直なリヤウォールがつながって構成されている。ゴールの内側は、ボールの衝撃を吸収し偏向速度を減じるための材質 - 例えば発泡材など - で覆われる必要がある。ゴールの壁と角と上面は白色で塗装される。 +
 Goals must be placed on the center of each goal line and anchored securely to the field surface. They consist of two 0.16 meters high vertical side walls joined at the back by a 0.16 meters high vertical rear wall. The inner face of the goal has to be covered with an energy absorbing material such as foam to help absorb ball impacts and lessen the speed of deflections. The goal walls, edges, and tops are white in color.
 
-サイドウォールの間の距離はディヴィジョンAであれば1.2mでディヴィジョンBであれば1mで、奥行は0.18mである。ゴールウォールの厚さは0.02mでゴールラインと接している。ただし、フィールドラインやフィールドに対して侵入したり重なったりしないようにしている。Figure 3とfigure 4にディヴィジョンAとディヴィジョンBの詳細をそれぞれ示す。 +
+サイドウォールの間の距離はディヴィジョンAであれば1.2mでディヴィジョンBであれば1mで、奥行は0.18mである。ゴールウォールの厚さは0.02mでゴールラインと接している。ただし、フィールドラインやフィールドに対して侵入したり重なったりしないようにしている。<<goal-detail-a, Figure 3>>と<<goal-detail-b, Figure 4>>にディヴィジョンAとディヴィジョンBの詳細をそれぞれ示す。 +
 The distance between the side walls is 1.2 meters for division A and 1 meter for division B, and the goal is 0.18 meters deep. The goal walls are 0.02 meters thick and touch the goal line, but do not overlap or encroach on the field lines or the field. <<goal-detail-a, Figure 3>> and <<goal-detail-b, figure 4>> show these details for division A and division B respectively.
 
 NOTE: 図中の数値はミリメートル表示の距離である +
@@ -94,12 +94,12 @@ The ball is a standard orange golf ball. It weights approximately 0.046 kilogram
 
 NOTE: (訳者注記)このルールの重さと直径は一般的なゴルフボールの規格を記載している。 
 
-公式な試合では、組織委員会/organizing committeeがボールを提供する。 +
-For official matches, the <<Organizing Committee, organizing committee>> provides the ball.
+公式な試合では、<<組織委員会/Organizing Committee, 組織委員会>>がボールを提供する。 +
+For official matches, the <<組織委員会/Organizing Committee, organizing committee>> provides the ball.
 
 === 共有ソフトウェア/Shared Software
-小型機リーグで使用される共有ソフトウェアは、技術委員会/technical committeeによって管理されているが、誰しもが貢献することを推奨する。技術委員会/technical committeeのメンバはしかしながら、次のロボカップの3か月前までに行われた、いかなる変更も互換性が損なわれていないことを保証する。 +
-The shared software used in the Small Size League is maintained by the <<Technical Committee, technical committee>>, though everyone is encouraged to contribute. The <<Technical Committee, technical committee>> members however guarantee that any changes made less than three months before the next RoboCup do not break compatibility.
+小型機リーグで使用される共有ソフトウェアは、<<技術委員会/Technical Committee, 技術委員会>>によって管理されているが、誰しもが貢献することを推奨する。<<技術委員会/Technical Committee, 技術委員会>>のメンバはしかしながら、次のロボカップの3か月前までに行われた、いかなる変更も互換性が損なわれていないことを保証する。 +
+The shared software used in the Small Size League is maintained by the <<技術委員会/Technical Committee, technical committee>>, though everyone is encouraged to contribute. The <<技術委員会/Technical Committee, technical committee>> members however guarantee that any changes made less than three months before the next RoboCup do not break compatibility.
 
 ==== Vision
 それぞれのフィールドには共有のビジョンサーバーと共有のカメラが設置されている。この共有ビジョン機器はコミュニティにメンテナンスされているSSL-Vision ソフトウェア(https://github.com/RoboCup-SSL/ssl-vision) が使用される。SSL-Visionはイーサーネット経由で競技会の前に共有ビジョンシステム開発者によって通達されたパケット形式で位置情報を各チームに提供する。各チームはシステムが共有ビジョンシステムと互換性があり、システムが共有ビジョンシステムによって提供される実際のセンサーのデータの(ノイズ、レイテンシ、誤検出、欠落を含む)典型的な特性を処理できることを確認する必要がある。ロボット最上部にあるビジョンパターンはSSL-Visionの仕様に準拠している必要があり、SSL-Visionのマニュアルで指定されている標準のカラーペーパーでなければならない。 +
@@ -111,25 +111,25 @@ Besides the shared vision equipment, teams are not allowed to mount their own ca
 NOTE: (訳者注)一般的に「ビジョン」と呼称されることが多い。
 
 ==== Game Controller
-試合はコミュニティにメンテナンスされているssl-game-controller (https://github.com/RoboCup-SSL/ssl-game-controller) によってコントロールされている。このソフトウェアはgame controller operatorによって操作されている。ソフトウェアは主審/refereeとautomatic refereeの決定をネットワークにブロードキャストされるイーサーネット通信の信号に変換する。これは、試合の状態を維持し、すべてのイベントを追跡し、試合に参加するすべての関係者間の代理として振る舞う。 +
+試合はコミュニティにメンテナンスされているssl-game-controller (https://github.com/RoboCup-SSL/ssl-game-controller) によってコントロールされている。このソフトウェアは<<Game Controller Operator, game controller operator>>によって操作されている。ソフトウェアは<<主審/Referee, 主審>>と<<Automatic Referee, automatic referee>>の決定をネットワークにブロードキャストされるイーサーネット通信の信号に変換する。これは、試合の状態を維持し、すべてのイベントを追跡し、試合に参加するすべての関係者間の代理として振る舞う。 +
 A game is controlled by the community-maintained ssl-game-controller (https://github.com/RoboCup-SSL/ssl-game-controller).
-It is operated by the <<Game Controller Operator, game controller operator>>. The software translates decisions of the <<Referee, referee>> and the <<Automatic Referee, automatic referee>> into Ethernet communication signals that are broadcast to the network. It maintains the state of the game, tracks all events and acts as a proxy between all participating parties in the game.
+It is operated by the <<Game Controller Operator, game controller operator>>. The software translates decisions of the <<主審/Referee, referee>> and the <<Automatic Referee, automatic referee>> into Ethernet communication signals that are broadcast to the network. It maintains the state of the game, tracks all events and acts as a proxy between all participating parties in the game.
 
-game-controllerは試合を行うチームのためにネットワークインターフェースを持っている。各チームはボールがout of playの時に、自動的にキーパーのIDを切り替える事ができるほか、次の機会に向けてロボットの移動を指示する信号を送信することや、advantage ruleの要求に応答することができる。 +
-The game-controller has a network interface for the playing teams. They can automatically change their keeper id when the ball is <<Ball In And Out Of Play, out of play>>, they can signal a robot substitution intent for the next opportunity and they can reply to requests of the <<Advantage Rule, advantage rule>>.
+game-controllerは試合を行うチームのためにネットワークインターフェースを持っている。各チームはボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>の時に、自動的にキーパーのIDを切り替える事ができるほか、次の機会に向けてロボットの移動を指示する信号を送信することや、<<アドバンテージルール/Advantage Rule, アドバンテージルール>>の要求に応答することができる。 +
+The game-controller has a network interface for the playing teams. They can automatically change their keeper id when the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>>, they can signal a robot substitution intent for the next opportunity and they can reply to requests of the <<アドバンテージルール/Advantage Rule, advantage rule>>.
 
 NOTE: (訳者注)日本では一般的に「レフボ」と呼称されることが多い。これは、同様の機能を持った旧世代のソフトウェアである「ssl-refbox」、およびその操作担当である「refbox operator」(2018年の大会をもって廃止)に由来する。
 
 ==== Automatic Referee
-ひとつないし複数のAutomatic Refereeアプリケーションはgame controllerに対して試合の取り締まりと反則/offensesの報告をすることができる。少なくとも1つのAutomatic refereeが試合ごとに必要である。もし1つ以上のAutomatic refereeがgame controllerに接続される場合、多数決を適用することができる。 +
-One or more automatic referee applications can supervise a game and report <<Offenses, offenses>> to the <<Game Controller, game controller>>.
+ひとつないし複数のAutomatic Refereeアプリケーションは<<Game Controller, game controller>>に対して試合の取り締まりと<<反則/Offenses, 反則>>の報告をすることができる。少なくとも1つのAutomatic refereeが試合ごとに必要である。もし1つ以上のAutomatic refereeがgame controllerに接続される場合、多数決を適用することができる。 +
+One or more automatic referee applications can supervise a game and report <<反則/Offenses, offenses>> to the <<Game Controller, game controller>>.
 At least one automatic referee is required per game. If more than one automatic referee is connected to the game controller, a majority vote can be applied.
 
-ソースコードがオープンソースであることを前提として、新たなautomatic refereeの実装を提供することができる。新しい実装は少なくとも競技会の3か月前までにアナウンスされなければならない。技術委員会/technical committeeはその実装を使用するかしないかを決定する。 +
-New automatic referee implementations can be provided, given that the source code is open-sourced. New implementations must be announced at least three months before the competition. The <<Technical Committee, technical committee>> decides if an implementation will be used or not.
+ソースコードがオープンソースであることを前提として、新たなautomatic refereeの実装を提供することができる。新しい実装は少なくとも競技会の3か月前までにアナウンスされなければならない。<<技術委員会/Technical Committee, 技術委員会>>はその実装を使用するかしないかを決定する。 +
+New automatic referee implementations can be provided, given that the source code is open-sourced. New implementations must be announced at least three months before the competition. The <<技術委員会/Technical Committee, technical committee>> decides if an implementation will be used or not.
 
-Game Event TableはAutomatic Refereeの実装がどのゲームイベントを検出できなけらばならないかを示す。 +
-The <<Game Event Table>> shows which game events an automatic referee implementation must be able to detect.
+<<ゲームイベント表/Game Event Table, ゲームイベント表>>はAutomatic Refereeの実装がどのゲームイベントを検出できなけらばならないかを示す。 +
+The <<ゲームイベント表/Game Event Table, Game Event Table>> shows which game events an automatic referee implementation must be able to detect.
 
 存在する実装はGithubで確認することができる。: https://github.com/RoboCup-SSL/ssl-autorefs +
 Existing implementations can be found on Github: https://github.com/RoboCup-SSL/ssl-autorefs.

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -20,11 +20,11 @@ NOTE: 図中の数値はミリメートル表示の距離である +
 The numbers in the figures below show the distances in millimeters.
 
 [[field-dimensions-a]]
-.Field dimensions and markings for division A
+.ディヴィジョンAにおけるフィールドの寸法と各マーキング/Field dimensions and markings for division A
 image::quad-size-field.png[]
 
 [[field-dimensions-b]]
-.Field dimensions and markings for division B
+.ディヴィジョンBにおけるフィールドの寸法と各マーキング/Field dimensions and markings for division B
 image::double-size-field.png[]
 
 [[reference-human-soccer-field]]
@@ -81,11 +81,11 @@ NOTE: 図中の数値はミリメートル表示の距離である +
 The numbers in the figures below show the distances in millimeters.
 
 [[goal-detail-a]]
-.The goal in detail for division A
+.ディヴィジョンAにおけるゴール詳細/The goal in detail for division A
 image::goal_detail_divisionA.png[width=400]
 
 [[goal-detail-b]]
-.The goal in detail for division B
+.ディヴィジョンBにおけるゴール詳細/The goal in detail for division B
 image::goal_detail_divisionB.png[width=400]
 
 === ボール/Ball

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -117,7 +117,7 @@ NOTE: (訳者注)一般的に「ビジョン」と呼称されることが多い
 A game is controlled by the community-maintained ssl-game-controller (https://github.com/RoboCup-SSL/ssl-game-controller).
 It is operated by the <<Game Controller Operator, game controller operator>>. The software translates decisions of the <<主審/Referee, referee>> and the <<Automatic Referee, automatic referee>> into Ethernet communication signals that are broadcast to the network. It maintains the state of the game, tracks all events and acts as a proxy between all participating parties in the game.
 
-game-controllerは試合を行うチームのためにネットワークインターフェースを持っている。各チームはボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>の時に、自動的にキーパーのIDを切り替える事ができるほか、次の機会に向けてロボットの移動を指示する信号を送信することや、<<アドバンテージルール/Advantage Rule, アドバンテージルール>>の要求に応答することができる。 +
+game-controllerは試合を行うチームのためにネットワークインターフェースを持っている。各チームはボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>の時に、自動的にキーパーのIDを切り替える事ができるほか、次の機会に向けてロボット交代の意図を伝えることや、<<アドバンテージルール/Advantage Rule, アドバンテージルール>>の要求に応答することができる。 +
 The game-controller has a network interface for the playing teams. They can automatically change their keeper id when the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>>, they can signal a robot substitution intent for the next opportunity and they can reply to requests of the <<アドバンテージルール/Advantage Rule, advantage rule>>.
 
 NOTE: (訳者注)日本では一般的に「レフボ」と呼称されることが多い。これは、同様の機能を持った旧世代のソフトウェアである「ssl-refbox」、およびその操作担当である「refbox operator」(2018年の大会をもって廃止)に由来する。

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -29,7 +29,9 @@ image::double-size-field.png[]
 
 [[reference-human-soccer-field]]
 image::lawsofthegame_201819_p35_field.png[]
-(訳者注記)参考 人間のサッカーの競技フィールド(出典:国際サッカー評議会著, 日本サッカー協会訳 "Laws of the Game 2018/19", P.35 https://www.jfa.jp/documents/pdf/soccer/lawsofthegame_201819.pdf]
+(訳者注記)参考 人間のサッカーの競技フィールド +
+(出典:国際サッカー評議会著, 日本サッカー協会訳 "Laws of the Game 2018/19", P.35 +
+https://www.jfa.jp/documents/pdf/soccer/lawsofthegame_201819.pdf)
 
 ==== フィールドの表面/Field Surface
 競技フィールドの表面は緑色のフェルトマットかカーペットである。カーペット下の床は固く平坦で水平である。 +

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -10,7 +10,7 @@ NOTE: ボールが高速に転がる場合、特にstop中はロボットに速�
 If the ball moves very quickly, it is hard to always keep the required distance to the ball, especially since the speed of the robots is limited during stop. Therefore, it is sufficient if it is obvious to the referee that the robots try their best to follow the distance rule.
 
 .用途/Usage
-stopコマンドはボールが(ゴールを含む)<<フィールドライン/Field Lines, フィールドライン>>を超えた後や反則が発生した後に競技を一時停止するために使われ、Haltやタイムアウト、automatic ball placementの再開を準備するために使われる。ロボットの速度制限とボールとの最小距離によって、主審や副審がボールを安全に干渉なく置くことができる。 +
+stopコマンドはボールが(ゴールを含む)<<フィールドライン/Field Lines, フィールドライン>>を超えた後や反則が発生した後に競技を一時停止するために使われ、Haltやタイムアウト、自動的なボール配置の再開を準備するために使われる。ロボットの速度制限とボールとの最小距離によって、主審や副審がボールを安全に干渉なく置くことができる。 +
 The stop command is used to pause the game after the ball crossed the <<フィールドライン/Field Lines, field lines>> (including goals) or an offense occurred as well as to prepare the start or resumption of the game after halt, timeouts and automatic ball placement. The robot speed limit and the minimum distance to the ball allow the referee or assistant referee to place the ball safely and without interference.
 
 NOTE: (訳者注)一般的に「ストップゲーム」もしくは単に「ストップ」と呼称されることが多い。
@@ -53,17 +53,17 @@ the ball is stationary
 * ボールは要求された位置から半径0.15m以内の場所に配置されている +
 the ball is at a position within 0.15 meters radius from the requested position
 
-automatic ball placementが完了するまで、<<Game Controller, game controller>>によってそれ以外のコマンドは発行されない。ボールが上手く配置された場合、試合は<<Game Controller, game controller>>によって可能な限り早く再開される(ただし、ボール配置コマンドが発行されてから2秒より早くはならない)。配置が失敗した場合、相手に間接フリーキックが与えられる。このチームがボールをうまく配置することに失敗した場合、ボールは<<主審/Referee, 主審>>により配置され、試合は元のコマンドによって続行される。 +
+ボールが正常に配置されるまで、<<Game Controller, game controller>>によってそれ以外のコマンドは発行されない。ボールが上手く配置された場合、試合は<<Game Controller, game controller>>によって可能な限り早く再開される(ただし、ボール配置コマンドが発行されてから2秒より早くはならない)。配置が失敗した場合、相手に間接フリーキックが与えられる。このチームがボールをうまく配置することに失敗した場合、ボールは<<主審/Referee, 主審>>により配置され、試合は元のコマンドによって続行される。 +
 No further commands will be issued by the <<Game Controller, game controller>> until the automatic placement is complete.
 The game will be continued by the <<Game Controller, game controller>> as soon as the ball is successfully placed, but not earlier than 2 seconds after the ball placement command has been issued.
 A failed placement will result in an indirect free kick for the opposing team.
 If this team failed to place the ball as well, the ball is placed by the <<主審/Referee, referee>> and game continues with the original command.
 
-配置を担当しない方のチームは<<ボール配置への干渉/Ball Placement Interference, ball placement taskを妨害>>してはいけない。 +
+配置を担当しない方のチームは<<ボール配置への干渉/Ball Placement Interference, ボール配置に干渉>>してはいけない。 +
 The non-placing team must not <<ボール配置への干渉/Ball Placement Interference, interfere the ball placement task>>.
 
 .用途/Usage
-ボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>のとき、automatic ball placementが適用されるのであれば、次のルールが決定される; +
+ボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>のとき、自動ボール配置が適用されるのであれば、次のルールが決定される; +
 When the ball goes <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>>, the following rules decide, if automatic ball placement is applied:
 
 . <<主審/Referee, 主審>>はすべてのキックオフとすべてのペナルティキックの時にボールを配置する +
@@ -72,11 +72,11 @@ The <<主審/Referee, referee>> has to place the ball for all kickoffs and all p
 For an <<間接フリーキック/Indirect Free Kick, indirect free kick>> or <<直接フリーキック/Direct Free Kick, direct free kick>>, the team that brings the ball <<インプレイとアウトオブプレイ/Ball In And Out Of Play, into play>> must place the ball
 . <<フォーススタート/Force Start, フォーススタート>>の場合、偶然選ばれたどちらか片方のチームがボールを配置しなければならない。 +
 For a <<フォーススタート/Force Start, force start>>, a team is drawn by chance and must place the ball
-. ball placementが開始される前は、ボールは見えていなければならず、フィールドコーナーやゴールコーナー、ゴールの後ろにボールが配置されてはいけない +
+. ボール配置が開始される前は、ボールは見えていなければならず、フィールドコーナーやゴールコーナー、ゴールの後ろにボールが配置されてはいけない +
 The ball must be visible and must not be inside a field corner, a goal corner or behind the goal, before the ball placement starts
 . <<主審/Referee, 主審>>はいつでもボールを手動で配置することを決定できる +
 The <<主審/Referee, referee>> can decide to place the ball manually at any time
-. <<主審/Referee, 主審>>は、試合の終わりまでautomatic ball placementを無効化とすることを決定できる。TC/OCはこの決定に同意しなければならない。 +
+. <<主審/Referee, 主審>>は、試合の終わりまで自動ボール配置を無効化とすることを決定できる。TC/OCはこの決定に同意しなければならない。 +
 The <<主審/Referee, referee>> can decide to disable automatic ball placement for the rest of the game. TC/OC must agree with this decision
 . 片方のチームが連続して5回ボールを配置することに失敗した場合、そのハーフが終わるまでボールを配置することは許されない。フィールド外に出てしまった事で発生したすべてのフリーキックは相手チームに与えられる。その他のルール違反や両チームともボールを配置することに失敗した場合、ボールは<<主審/Referee, 主審>>によって配置される +
 When a team has failed to place the ball 5 times in a row, it is not allowed to place the ball for the rest of the game half. All free kicks that were a result of the ball leaving the field, are awarded to the opposing team. For all other rule violations or when both teams failed to place the ball, the ball is placed by the <<主審/Referee, referee>>

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -178,7 +178,7 @@ NOTE: (訳者注)一般的に「インダイレクトフリーキック」もし
 When the force start command is issued, the game is immediately resumed and both teams are allowed to approach and <<ボールの操作/Ball Manipulation, manipulate the ball>> again.
 
 .用途/Usage
-主審は両方のチームがボールに近づき<<ボールの操作/Ball Manipulation, 操作する>>ことが許可されている間に、少なくとも10秒間試合が進行していることが明確でない場合には、stopコマンド停止コマンドの後にforce startコマンドを発行することができる。 +
+主審は両方のチームがボールに近づき<<ボールの操作/Ball Manipulation, 操作する>>ことが許可されている間に、少なくとも10秒間試合が進行していることが明確でない場合には、Stopコマンドの後にforce startコマンドを発行することができる。 +
 The referee can issue a stop command followed by force start if there is a clear lack of progress for at least 10 seconds while both teams are allowed to approach and <<ボールの操作/Ball Manipulation, manipulate the ball>>.
 
 また、ゲームを止めなければならず、両方のチームに不具合がない場合、もしくは両方のチームに不具合がある場合に、試合を再開するために使用することもできる。 +

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -3,30 +3,30 @@
 === 試合の停止/Stopping The Game
 ==== 停止/Stop
 .定義/Definition
-stopコマンドが発行されると、すべてのロボットは1.5m/s以下まで減速しなければならない。さらに、すべてのロボットは少なくともボールから0.5m離れた位置にいる必要があり、ボールを操作することも許されない。 +
-When the stop command is issued, all robots have to slow down to less than 1.5 m/s. Additionally, all robots have to keep at least 0.5 meters distance to the ball and are not allowed to <<Ball Manipulation, manipulate the ball>>.
+stopコマンドが発行されると、すべてのロボットは1.5m/s以下まで減速しなければならない。さらに、すべてのロボットは少なくともボールから0.5m離れた位置にいる必要があり、<<ボールの操作/Ball Manipulation, ボールを操作すること>>も許されない。 +
+When the stop command is issued, all robots have to slow down to less than 1.5 m/s. Additionally, all robots have to keep at least 0.5 meters distance to the ball and are not allowed to <<ボールの操作/Ball Manipulation, manipulate the ball>>.
 
 NOTE: ボールが高速に転がる場合、特にstop中はロボットに速度制限があるのでボールとの距離の制約を常に守ることは困難である。したがって、距離制約に従うためにロボットが最善を尽くしていることが主審には明らかであれば十分である。 +
 If the ball moves very quickly, it is hard to always keep the required distance to the ball, especially since the speed of the robots is limited during stop. Therefore, it is sufficient if it is obvious to the referee that the robots try their best to follow the distance rule.
 
 .用途/Usage
-stopコマンドはボールが(ゴールを含む)フィールドラインを超えた後や反則が発生した後に競技を一時停止するために使われ、Haltやタイムアウト、automatic ball placementの再開を準備するために使われる。ロボットの速度制限とボールとの最小距離によって、主審や副審がボールを安全に干渉なく置くことができる。 +
-The stop command is used to pause the game after the ball crossed the <<Field Lines, field lines>> (including goals) or an offense occurred as well as to prepare the start or resumption of the game after halt, timeouts and automatic ball placement. The robot speed limit and the minimum distance to the ball allow the referee or assistant referee to place the ball safely and without interference.
+stopコマンドはボールが(ゴールを含む)<<フィールドライン/Field Lines, フィールドライン>>を超えた後や反則が発生した後に競技を一時停止するために使われ、Haltやタイムアウト、automatic ball placementの再開を準備するために使われる。ロボットの速度制限とボールとの最小距離によって、主審や副審がボールを安全に干渉なく置くことができる。 +
+The stop command is used to pause the game after the ball crossed the <<フィールドライン/Field Lines, field lines>> (including goals) or an offense occurred as well as to prepare the start or resumption of the game after halt, timeouts and automatic ball placement. The robot speed limit and the minimum distance to the ball allow the referee or assistant referee to place the ball safely and without interference.
 
 NOTE: (訳者注)一般的に「ストップゲーム」もしくは単に「ストップ」と呼称されることが多い。
 
 ==== ハルト/Halt
 .定義/Definition
-haltコマンドが発行されると、すべてのロボットは動作を停止し、ボールを操作してはいけない。 +
-When the halt command is issued, no robot is allowed to move or <<Ball Manipulation, manipulate the ball>>.
+haltコマンドが発行されると、すべてのロボットは動作を停止し、<<ボールの操作/Ball Manipulation, ボールを操作>>してはいけない。 +
+When the halt command is issued, no robot is allowed to move or <<ボールの操作/Ball Manipulation, manipulate the ball>>.
 
 ロボットが減速するために2秒間の猶予がある。 +
 There is a grace period of 2 seconds for the robots to brake.
 
 .用途/Usage
-(例えばロボットが制御不能になった時など)緊急事態が発生した時に主審はhaltコマンドで試合を中断させることができる。また、Vision expertが必要と判断した場合にはVision ソフトウェアの再キャリブレーションにも使われ、主審が同意する場合にはロボットの交代にも使われる。さらに、主審は自由にhaltコマンドを発行することができる。 +
+(例えばロボットが制御不能になった時など)緊急事態が発生した時に主審はhaltコマンドで試合を中断させることができる。また、Vision expertが必要と判断した場合にはVisionソフトウェアの再キャリブレーションにも使われ、主審が同意する場合には<<ロボットの交代/Robot Substitution, ロボットの交代>>にも使われる。さらに、主審は自由にhaltコマンドを発行することができる。 +
 The halt command allows the referee to interrupt the game immediately whenever an emergency occurs (for example when a robot gets out of contol). It is
-also used to recalibrate the vision software during a game if the vision expert considers it necessary and the referee agrees and for <<Robot Substitution, robot substitution>>. Additionally, the referee is free to issue the halt command at will.
+also used to recalibrate the vision software during a game if the vision expert considers it necessary and the referee agrees and for <<ロボットの交代/Robot Substitution, robot substitution>>. Additionally, the referee is free to issue the halt command at will.
 
 haltコマンドの後は常にstopコマンドが送信される。 +
 The halt command is always followed up by stop.
@@ -34,54 +34,54 @@ The halt command is always followed up by stop.
 
 === ボール配置/Ball Placement
 .定義/Definition
-ゲームが停止中に、発生したイベントに応じてボールは適切な位置におかなければならない。automatic ball placementは人による介入なしにロボットによってフィールド上の指定された位置にボールを置くことができる、望ましい方法である。もしこれが無理な場合、主審が手動で配置する。 +
+ゲームが停止中に、発生したイベントに応じてボールは適切な位置におかなければならない。automatic ball placementは人による介入なしにロボットによってフィールド上の指定された位置にボールを置くことができる、望ましい方法である。もしこれが無理な場合、<<主審/Referee, 主審>>が手動で配置する。 +
 After the game was stopped, the ball must be placed on the appropriate position, depending on the event that occurred.
 The automatic ball placement is the preferred way to place the ball at the designated position on the field by the robots of the teams without human interaction.
-If this is not possible, the <<Referee, referee>> places the ball manually.
+If this is not possible, the <<主審/Referee, referee>> places the ball manually.
 
 ボールがロボットによってうまく配置されたと考えられるのは以下の場合である +
 A ball is considered placed successfully by the robots if
 
 * 配置コマンドが発行されてから30秒以内 +
 no more than 30 seconds passed since the placement command
-* 次のコマンドがボール配置を担当するチームの間接フリーキックか直接フリーキックの場合、ボールまでの距離が0.05m以内のロボットが存在しない +
-there is no robot within 0.05 meters distance to the ball if the next command is an <<Indirect Free Kick, indirect free kick>> or <<Direct Free Kick, direct free kick>> for the placing team
-* 次のコマンドがforce startの場合、ボールまでの距離が0.5m以内のロボットが存在しない +
-there is no robot within 0.5 meters distance to the ball if the next command is a <<Force Start, force start>>
+* 次のコマンドがボール配置を担当するチームの<<間接フリーキック/Indirect Free Kick, 間接フリーキック>>か<<直接フリーキック/Direct Free Kick, 直接フリーキック>>の場合、ボールまでの距離が0.05m以内のロボットが存在しない +
+there is no robot within 0.05 meters distance to the ball if the next command is an <<間接フリーキック/Indirect Free Kick, indirect free kick>> or <<直接フリーキック/Direct Free Kick, direct free kick>> for the placing team
+* 次のコマンドが<<フォーススタート/Force Start, force start>>の場合、ボールまでの距離が0.5m以内のロボットが存在しない +
+there is no robot within 0.5 meters distance to the ball if the next command is a <<フォーススタート/Force Start, force start>>
 * ボールは静止している +
 the ball is stationary
 * ボールは要求された位置から半径0.15m以内の場所に配置されている +
 the ball is at a position within 0.15 meters radius from the requested position
 
-automatic ball placementが完了するまで、game controllerによってそれ以外のコマンドは発行されない。ボールが上手く配置された場合、試合はgame controllerによって可能な限り早く再開される(ただし、ボール配置コマンドが発行されてから2秒より早くはならない)。配置が失敗した場合、相手に間接フリーキックが与えられる。このチームがボールをうまく配置することに失敗した場合、ボールは審判により配置され、試合は元のコマンドによって続行される。 +
+automatic ball placementが完了するまで、<<Game Controller, game controller>>によってそれ以外のコマンドは発行されない。ボールが上手く配置された場合、試合は<<Game Controller, game controller>>によって可能な限り早く再開される(ただし、ボール配置コマンドが発行されてから2秒より早くはならない)。配置が失敗した場合、相手に間接フリーキックが与えられる。このチームがボールをうまく配置することに失敗した場合、ボールは<<主審/Referee, 主審>>により配置され、試合は元のコマンドによって続行される。 +
 No further commands will be issued by the <<Game Controller, game controller>> until the automatic placement is complete.
 The game will be continued by the <<Game Controller, game controller>> as soon as the ball is successfully placed, but not earlier than 2 seconds after the ball placement command has been issued.
 A failed placement will result in an indirect free kick for the opposing team.
-If this team failed to place the ball as well, the ball is placed by the <<Referee, referee>> and game continues with the original command.
+If this team failed to place the ball as well, the ball is placed by the <<主審/Referee, referee>> and game continues with the original command.
 
-配置を担当しない方のチームはball placement taskを妨害してはいけない。 +
-The non-placing team must not <<Ball Placement Interference, interfere the ball placement task>>.
+配置を担当しない方のチームは<<ボール配置への干渉/Ball Placement Interference, ball placement taskを妨害>>してはいけない。 +
+The non-placing team must not <<ボール配置への干渉/Ball Placement Interference, interfere the ball placement task>>.
 
 .用途/Usage
-ボールがアウトオブプレイのとき、automatic ball placementが適用されるのであれば、次のルールが決定される; +
-When the ball goes <<Ball In And Out Of Play, out of play>>, the following rules decide, if automatic ball placement is applied:
+ボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>のとき、automatic ball placementが適用されるのであれば、次のルールが決定される; +
+When the ball goes <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>>, the following rules decide, if automatic ball placement is applied:
 
-. 主審はすべてのキックオフとすべてのペナルティキックの時にボールを配置する +
-The <<Referee, referee>> has to place the ball for all kickoffs and all penalty kicks
-. 間接フリーキックと直接フリーキックの場合、ボールをインプレイにするチームがボールを配置しなければならない +
-For an <<Indirect Free Kick, indirect free kick>> or <<Direct Free Kick, direct free kick>>, the team that brings the ball <<Ball In And Out Of Play, into play>> must place the ball
-. フォーススタートの場合、偶然選ばれたどちらか片方のチームがボールを配置しなければならない。 +
-For a <<Force Start, force start>>, a team is drawn by chance and must place the ball
+. <<主審/Referee, 主審>>はすべてのキックオフとすべてのペナルティキックの時にボールを配置する +
+The <<主審/Referee, referee>> has to place the ball for all kickoffs and all penalty kicks
+. <<間接フリーキック/Indirect Free Kick, 間接フリーキック>>と<<直接フリーキック/Direct Free Kick, 直接フリーキック>>の場合、ボールを<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>にするチームがボールを配置しなければならない +
+For an <<間接フリーキック/Indirect Free Kick, indirect free kick>> or <<直接フリーキック/Direct Free Kick, direct free kick>>, the team that brings the ball <<インプレイとアウトオブプレイ/Ball In And Out Of Play, into play>> must place the ball
+. <<フォーススタート/Force Start, フォーススタート>>の場合、偶然選ばれたどちらか片方のチームがボールを配置しなければならない。 +
+For a <<フォーススタート/Force Start, force start>>, a team is drawn by chance and must place the ball
 . ball placementが開始される前は、ボールは見えていなければならず、フィールドコーナーやゴールコーナー、ゴールの後ろにボールが配置されてはいけない +
 The ball must be visible and must not be inside a field corner, a goal corner or behind the goal, before the ball placement starts
-. 主審はいつでもボールを手動で配置することを決定できる +
-The <<Referee, referee>> can decide to place the ball manually at any time
-. 主審は、試合の終わりまでautomatic ball placementを無効化とすることを決定できる。TC/OCはこの決定に同意しなければならない。 +
-The <<Referee, referee>> can decide to disable automatic ball placement for the rest of the game. TC/OC must agree with this decision
-. 片方のチームが連続して5回ボールを配置することに失敗した場合、そのハーフが終わるまでボールを配置することは許されない。フィールド外に出てしまった事で発生したすべてのフリーキックは相手チームに与えられる。その他のルール違反や両チームともボールを配置することに失敗した場合、ボールは主審によって配置される +
-When a team has failed to place the ball 5 times in a row, it is not allowed to place the ball for the rest of the game half. All free kicks that were a result of the ball leaving the field, are awarded to the opposing team. For all other rule violations or when both teams failed to place the ball, the ball is placed by the <<Referee, referee>>
-. もしボール配置できるチームがいない場合、ボールは主審か副審によって配置される。主審または副審は、ボールを動かすために、いわゆるボールハンドラ（長い、できれば黒の棒状のデバイス）を使用することが推奨される。 +
-If no team can place the ball, the ball is placed by the <<Referee, referee>> or the <<Assistant Referee, assistant referee>>. Both the referee as well as the assistant referee are advised to use a so-called ball handler (a long, preferably black stick-like device) to move the ball.
+. <<主審/Referee, 主審>>はいつでもボールを手動で配置することを決定できる +
+The <<主審/Referee, referee>> can decide to place the ball manually at any time
+. <<主審/Referee, 主審>>は、試合の終わりまでautomatic ball placementを無効化とすることを決定できる。TC/OCはこの決定に同意しなければならない。 +
+The <<主審/Referee, referee>> can decide to disable automatic ball placement for the rest of the game. TC/OC must agree with this decision
+. 片方のチームが連続して5回ボールを配置することに失敗した場合、そのハーフが終わるまでボールを配置することは許されない。フィールド外に出てしまった事で発生したすべてのフリーキックは相手チームに与えられる。その他のルール違反や両チームともボールを配置することに失敗した場合、ボールは<<主審/Referee, 主審>>によって配置される +
+When a team has failed to place the ball 5 times in a row, it is not allowed to place the ball for the rest of the game half. All free kicks that were a result of the ball leaving the field, are awarded to the opposing team. For all other rule violations or when both teams failed to place the ball, the ball is placed by the <<主審/Referee, referee>>
+. もしボール配置できるチームがいない場合、ボールは<<主審/Referee, 主審>>か<<副審/Assistant Referee, 副審>>によって配置される。主審または副審は、ボールを動かすために、いわゆるボールハンドラ（長い、できれば黒の棒状のデバイス）を使用することが推奨される。 +
+If no team can place the ball, the ball is placed by the <<主審/Referee, referee>> or the <<副審/Assistant Referee, assistant referee>>. Both the referee as well as the assistant referee are advised to use a so-called ball handler (a long, preferably black stick-like device) to move the ball.
 
 NOTE: ボールがすでに配置位置にある場合（たとえば、他のチームによるフリーキックの失敗後）、ロボットがボールを操作しなくてもボール配置は成功する可能性がある。これは、配置チームによる貢献なしに失敗回数のカウンターのリセットにつながる可能性がある。 +
 If the ball is already at the placement position (for example after a failed free kick by the other team), the ball placement can be successful without a robot manipulating the ball. This could lead to the counter for failed attempts resetting without a contribution by the placing team.
@@ -89,11 +89,11 @@ If the ball is already at the placement position (for example after a failed fre
 NOTE: placementコマンドが発行された時点では、ボールはまだ動いている可能性がある。 +
 The ball may still be moving when the placement command is issued.
 
-ディヴィジョンAのすべてのチームでボールの配置が必須である。ディヴィジョンBのチームは主審と話すことによって、試合中や試合のいつでも試合の残り時間でボール配置をしないことを決定しても良い。主審はgame controller operatorに対してそのチームのボール配置を無効にするように指示する。この場合、チームは相手チームがボールを配置した後にボールをインプレイに持ち込むことができる。もし相手チームがボール配置に失敗したり、ボール配置ができるチームがいない場合は、ボールは主審か副審によって配置される。 +
+ディヴィジョンAのすべてのチームでボールの配置が必須である。ディヴィジョンBのチームは<<主審/Referee, 主審>>と話すことによって、試合中や試合のいつでも試合の残り時間でボール配置をしないことを決定しても良い。主審は<<Game Controller Operator, game controller operator>>に対してそのチームのボール配置を無効にするように指示する。この場合、チームは相手チームがボールを配置した後にボールをインプレイに持ち込むことができる。もし相手チームがボール配置に失敗したり、ボール配置ができるチームがいない場合は、ボールは<<主審/Referee, 主審>>か<<副審/Assistant Referee, 副審>>によって配置される。 +
 Ball placement is mandatory for all teams in division A.
-Teams in division B may decide, at any time before or during the game, not to place the ball for the rest of the game by talking to the <<Referee, referee>>, who in turn tells the <<Game Controller Operator, game controller operator>> to disable ball placement for this team.
+Teams in division B may decide, at any time before or during the game, not to place the ball for the rest of the game by talking to the <<主審/Referee, referee>>, who in turn tells the <<Game Controller Operator, game controller operator>> to disable ball placement for this team.
 In this case, the team is allowed to bring the ball into play, after the ball was placed by the opposing team.
-If the opposing team fails to place the ball or no team can place the ball, it is placed by the <<Referee, referee>> or the <<Assistant Referee, assistant referee>>.
+If the opposing team fails to place the ball or no team can place the ball, it is placed by the <<主審/Referee, referee>> or the <<副審/Assistant Referee, assistant referee>>.
 
 NOTE: (訳者注)一般的に「ボールプレースメント」と呼称されることが多い。
 
@@ -101,18 +101,18 @@ NOTE: (訳者注)一般的に「ボールプレースメント」と呼称され
 ボール配置完了後、試合は以下のコマンドのうちのどれかを使用して再開される。 +
 After the ball has been placed, the game is resumed using one of the following commands.
 
-// In division A, the ball will be placed automatically by the robots if the following command is a free kick or force start (see <<Ball Placement>>).
+// In division A, the ball will be placed automatically by the robots if the following command is a free kick or force start (see <<ボール配置/Ball Placement>>).
 
 ==== ノーマルスタート/Normal Start
 .定義/Definition
-2段階式コマンドの場合、Normal startが送信されると、アタッカーがボールを操作することになる。Normal startから直接試合を再開することはできない。 +
-For two-staged referee commands, when normal start is sent, an attacker may <<Ball Manipulation, manipulate the ball>>. A match cannot be resumed directly via normal start.
+2段階式コマンドの場合、Normal startが送信されると、アタッカーが<<ボールの操作/Ball Manipulation, ボールを操作する>>ことになる。Normal startから直接試合を再開することはできない。 +
+For two-staged referee commands, when normal start is sent, an attacker may <<ボールの操作/Ball Manipulation, manipulate the ball>>. A match cannot be resumed directly via normal start.
 
 .用途/Usage
-Normal startはキックオフ、ペナルティキック、シュートアウトの時に使用する。 +
-Normal start is used for <<Kick-Off, kick-offs>>, <<Penalty Kick, penalty kicks>> and <<Shoot-Out, shoot-out>>.
+Normal startは<<キックオフ/Kick-Off, キックオフ>>、<<ペナルティーキック/Penalty Kick, ペナルティキック>>、<<シュートアウト/Shoot-Out, シュートアウト>>の時に使用する。 +
+Normal start is used for <<キックオフ/Kick-Off, kick-offs>>, <<ペナルティーキック/Penalty Kick, penalty kicks>> and <<シュートアウト/Shoot-Out, shoot-out>>.
 
-NOTE: (訳者注記)この小節で言いたいのは、試合が停止しているときにいきなりNormal Startコマンドが送信されることはなくて、キックオフやペナルティキックのコマンドが送信されてからその次にNormal startのコマンドが送信されるという事。
+NOTE: (訳者注記)この小節で言いたいのは、試合が停止しているときにいきなりNormal Startコマンドが送信されることはなくて、キックオフやペナルティーキックのコマンドが送信されてからその次にNormal startのコマンドが送信されるという事。
 
 ==== キックオフ/Kick-Off
 .定義/Definition
@@ -122,40 +122,40 @@ The ball has to be placed in the center of the field by the human referee.
 kick-offコマンドが発行されたとき、すべてのロボットはセンターサークルを除く自分たちの陣地側のフィールド半面に移動しなければならない。ただし、攻撃側チームのアタッカーロボット1台はセンターサークル内に侵入することが許可される。このロボットはキッカーと呼ばれる。すべてのロボットはボールに触れてはいけない。 +
 When the kick-off command is issued, all robots have to move to their own half of the field excluding the <<Center Circle, center circle>>. However, one robot of the attacking team is also allowed to be inside the whole center circle. This robot will be referred to as the kicker. No robot is allowed to touch the ball.
 
-normal startコマンドが送信されたとき、キッカーはボールをシュートすることが許可される。キックオフからゴールを直接獲得することができる。 +
-When the <<Normal Start, normal start>> command is issued, the kicker is allowed to shoot the ball. A goal may be scored directly from the kick-off.
+<<ノーマルスタート/Normal Start, normal start>>コマンドが送信されたとき、キッカーはボールをシュートすることが許可される。キックオフからゴールを直接獲得することができる。 +
+When the <<ノーマルスタート/Normal Start, normal start>> command is issued, the kicker is allowed to shoot the ball. A goal may be scored directly from the kick-off.
 
-ボールがインプレイになっているとき、キッカーは他のロボットがボールに触れるか、ゲームが停止するまでボールに触れてはいけない(ダブルタッチを参照)。また、ロボットの位置に関する制限が解除される。 +
-When the ball is <<Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
+ボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>になっているとき、キッカーは他のロボットがボールに触れるか、ゲームが停止するまでボールに触れてはいけない(「<<ダブルタッチ/Double Touch, ダブルタッチ>>」を参照)。また、ロボットの位置に関する制限が解除される。 +
+When the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<ダブルタッチ/Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
 
 .用途/Usage
-両方のハーフタイムだけでなく、両方の延長戦の時間はキックオフから始まる。競技の準備の章ではどのように攻撃側チームを決定するかを説明している。 +
-Both half times as well as both overtime periods (if needed) start with a kick-off. Chapter <<Match Preparation>> describes how to determine the attacking team.
+両方のハーフタイムだけでなく、両方の延長戦の時間はキックオフから始まる。<<競技の準備/Match Preparation, 「競技の準備」>>の章ではどのように攻撃側チームを決定するかを説明している。 +
+Both half times as well as both overtime periods (if needed) start with a kick-off. Chapter <<競技の準備/Match Preparation, [Match Preparation]>> describes how to determine the attacking team.
 
 さらに、ゴールが得点になった後、得点されたチームはキックオフで試合を再開する。 +
 Additionally, after a goal has been scored, the receiving team restarts the game with a kick-off.
 
 ==== 直接フリーキック/Direct Free Kick
 .定義/Definition
-フリーキックのためのボールの配置位置は、フリーキックの原因となったイベントによって異なる。この位置はすべてのフィールドラインから少なくとも0.2m、それぞれのディフェンスエリアから1m以上離れているときに有効である。もし、このルールが適用できないところにボールを配置する必要がある場合、その位置から最も近い有効な位置にボールを配置する必要がある。 +
-The ball placement position for a free kick depends on the event that led to the free kick. This position is valid if there is at least 0.2 meters distance to all <<Field Lines, field lines>> and 1 meter distance to either <<Defense Area, defense area>>. If an event requires the ball to be placed at a position that contravenes this rule, it has to be placed at the closest valid position instead.
+フリーキックのためのボールの配置位置は、フリーキックの原因となったイベントによって異なる。この位置はすべての<<フィールドライン/Field Lines, フィールドライン>>から少なくとも0.2m、それぞれの<<ディフェンスエリア/Defense Area, ディフェンスエリア>>から1m以上離れているときに有効である。もし、このルールが適用できないところにボールを配置する必要がある場合、その位置から最も近い有効な位置にボールを配置する必要がある。 +
+The ball placement position for a free kick depends on the event that led to the free kick. This position is valid if there is at least 0.2 meters distance to all <<フィールドライン/Field Lines, field lines>> and 1 meter distance to either <<ディフェンスエリア/Defense Area, defense area>>. If an event requires the ball to be placed at a position that contravenes this rule, it has to be placed at the closest valid position instead.
 
 直接フリーキックのコマンドが発行されたとき、攻撃側チームのロボットはボールに近づくことが許可され、防御側チームのロボットはボールから少なくとも0.5mは離れていなければならない(試合が停止中と同じ距離)。攻撃側チームのロボット1台はボールを蹴ることが許される。このロボットはキッカーと呼ばれる。直接フリーキックから直接ゴールに入った場合それは得点になる。 +
 When the direct free kick command is issued, robots of the attacking team are allowed to approach the ball while robots of the defending team still have to stay at least 0.5 meters distance away from the ball (the same distance as in stop). One robot of the attacking team is allowed to shoot the ball. This robot will be referred to as the kicker. A goal may be scored directly from the direct free kick.
 
 ボールがインプレイになっているとき、キッカーは他のロボットがボールに触れるか、ゲームが停止するまでボールに触れてはいけない(ダブルタッチを参照)。また、ロボットの位置に関する制限が解除される。 +
-When the ball is <<Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
+When the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<ダブルタッチ/Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
 
 .用途/Usage
-直接フリーキックはファウルが発生した後に試合を再開するために使われる。さらに、ゴールキックとコーナーキックも直接フリーキックに割り当てられている。 +
-Direct free kicks are used to restart the game after a <<Fouls, foul>> has occured. Additionally, <<Goal Kick, goal kicks>> and <<Corner Kick, corner kicks>> are mapped to direct free kicks.
+直接フリーキックは<<ファウル/Fouls, ファウル>>が発生した後に試合を再開するために使われる。さらに、<<ゴールキック/Goal Kick, ゴールキック>>と<<コーナーキック/Corner Kick, コーナーキック>>も直接フリーキックに割り当てられている。 +
+Direct free kicks are used to restart the game after a <<ファウル/Fouls, foul>> has occured. Additionally, <<ゴールキック/Goal Kick, goal kicks>> and <<コーナーキック/Corner Kick, corner kicks>> are mapped to direct free kicks.
 
 NOTE: (訳者注)一般的に「ダイレクトフリーキック」もしくは単に「ダイレクト」と呼称されることが多い。
 
 ==== 間接フリーキック/Indirect Free Kick
 .定義/Definition
-間接フリーキックは直接フリーキックと似ているが違いがある：間接フリーキックのあと、ボールがプレーに入った後で、守備側チームのゴールに入る前にボールが攻撃側チームのロボットに接触した場合にのみ、ゴールで得点が得られる。ボールが攻撃側のロボットの1台にも触れることなく守備側のチームのゴールに入った場合は、ゴール外のゴールラインを横切ったように扱う。 +
-An indirect free kick behaves like a <<Direct Free Kick,direct free kick>>, except: After an indirect free kick, a goal can only be scored if the ball touches a robot of the attacking team after the ball <<Resuming The Game, entered play>> and before it entering the goal of the defending team. If the ball enters the goal of the defending team without touching an attacking robot, it will be treated like it crossed the goal line outside the goal.
+間接フリーキックは<<直接フリーキック/Direct Free Kick, 直接フリーキック>>と似ているが違いがある：間接フリーキックのあと、ボールが<<試合の再開/Resuming The Game, プレーに入った>>後で、守備側チームのゴールに入る前にボールが攻撃側チームのロボットに接触した場合にのみ、ゴールで得点が得られる。ボールが攻撃側のロボットの1台にも触れることなく守備側のチームのゴールに入った場合は、ゴール外のゴールラインを横切ったように扱う。 +
+An indirect free kick behaves like a <<直接フリーキック/Direct Free Kick,direct free kick>>, except: After an indirect free kick, a goal can only be scored if the ball touches a robot of the attacking team after the ball <<試合の再開/Resuming The Game, entered play>> and before it entering the goal of the defending team. If the ball enters the goal of the defending team without touching an attacking robot, it will be treated like it crossed the goal line outside the goal.
 
 攻撃側チームのゴールにボールが入ってしまった場合(オウンゴール)は、守備側チームにゴールが与えられる。 +
 If the ball enters the goal of the attacking team (an own goal), a goal will be awarded to the defending team.
@@ -167,82 +167,82 @@ NOTE: (人間の)サッカーでは、(キーパーを含む)いずれかのプ�
 In association football, it is sufficient if any player (including the keeper) touches the ball before it enters the goal. To discourage the teams to shoot directly at the goal and hope that the keeper touches it, the rules of the Small Size League require a second touch of an attacking robot.
 
 .用途/Usage
-間接フリーキックは軽微な違反が発生した時に試合を再開するために使用する。さらにスローインも間接フリーキックに割り当てられている。 +
-Indirect free kicks are used to restart the game after a <<Minor Offenses, minor offense>> has occured. Additionally, <<Throw-In, throw-ins>> are mapped to indirect free kicks.
+間接フリーキックは<<軽微な違反/Minor Offenses, 軽微な違反>>が発生した時に試合を再開するために使用する。さらに<<スローイン/Throw-In, スローイン>>も間接フリーキックに割り当てられている。 +
+Indirect free kicks are used to restart the game after a <<軽微な違反/Minor Offenses, minor offense>> has occured. Additionally, <<スローイン/Throw-In, throw-ins>> are mapped to indirect free kicks.
 
 NOTE: (訳者注)一般的に「インダイレクトフリーキック」もしくは単に「インダイレクト」と呼称されることが多い。
 
 ==== フォーススタート/Force Start
 .定義/Definition
-フォーススタートのコマンドが発行されたとき、試合はすぐに再開され、どちらのチームもボールに近づき操作することが再び許可される。 +
-When the force start command is issued, the game is immediately resumed and both teams are allowed to approach and <<Ball Manipulation, manipulate the ball>> again.
+フォーススタートのコマンドが発行されたとき、試合はすぐに再開され、どちらのチームもボールに近づき<<ボールの操作/Ball Manipulation, 操作する>>ことが再び許可される。 +
+When the force start command is issued, the game is immediately resumed and both teams are allowed to approach and <<ボールの操作/Ball Manipulation, manipulate the ball>> again.
 
 .用途/Usage
-主審は両方のチームがボールに近づき操作することが許可されている間に、少なくとも10秒間試合が進行していることが明確でない場合には、stopコマンド停止コマンドの後にforce startコマンドを発行することができる。 +
-The referee can issue a stop command followed by force start if there is a clear lack of progress for at least 10 seconds while both teams are allowed to approach and <<Ball Manipulation, manipulate the ball>>.
+主審は両方のチームがボールに近づき<<ボールの操作/Ball Manipulation, 操作する>>ことが許可されている間に、少なくとも10秒間試合が進行していることが明確でない場合には、stopコマンド停止コマンドの後にforce startコマンドを発行することができる。 +
+The referee can issue a stop command followed by force start if there is a clear lack of progress for at least 10 seconds while both teams are allowed to approach and <<ボールの操作/Ball Manipulation, manipulate the ball>>.
 
 また、ゲームを止めなければならず、両方のチームに不具合がない場合、もしくは両方のチームに不具合がある場合に、試合を再開するために使用することもできる。 +
 It can also be used to resume the game when the game had to be stopped and no team or both teams are at fault.
 
 ==== ペナルティーキック/Penalty Kick
 .定義/Definition
-ペナルティーキックを開始するには、停止コマンドを送信しなければならず、ボールは人間の主審によってペナルティマーク上に配置されなければならない。 +
-To initiate a penalty kick, the stop command has to be sent and the ball has to be placed on the <<Penalty Mark, penalty mark>> by the human <<Referee, referee>>.
+ペナルティーキックを開始するには、停止コマンドを送信しなければならず、ボールは人間の<<主審/Referee, 主審>>によって<<ペナルティーマーク/Penalty Mark, ペナルティマーク>>上に配置されなければならない。 +
+To initiate a penalty kick, the stop command has to be sent and the ball has to be placed on the <<ペナルティーマーク/Penalty Mark, penalty mark>> by the human <<主審/Referee, referee>>.
 
-penaltyコマンドが発行されたとき、1台の攻撃側ロボットはボールに触れない範囲で近づくことが許可される。このロボットはキッカーと呼ばれる。守備をするキーパーはゴールラインに触れていなけばならない。それ以外のすべてのロボットは、ゴールラインと平行でペナルティマークから0.4m後ろにあたる線より後ろに移動する必要がある。これらの制約が満たされたら主審はnormal startコマンドにより続けることができる。 +
-When the penalty command is issued, one attacking robot is allowed to approach but not touch the ball. This robot will be referred to as the kicker. The defending keeper has to touch the goal line. All other robots have to move behind a line parallel to the goal line and 0.4 meters behind the penalty mark. When these constraints are met, the referee may continue with a <<Normal Start, normal start>> command.
+penaltyコマンドが発行されたとき、1台の攻撃側ロボットはボールに触れない範囲で近づくことが許可される。このロボットはキッカーと呼ばれる。守備をするキーパーはゴールラインに触れていなけばならない。それ以外のすべてのロボットは、ゴールラインと平行でペナルティマークから0.4m後ろにあたる線より後ろに移動する必要がある。これらの制約が満たされたら主審は<<ノーマルスタート/Normal Start, normal start>>コマンドにより続けることができる。 +
+When the penalty command is issued, one attacking robot is allowed to approach but not touch the ball. This robot will be referred to as the kicker. The defending keeper has to touch the goal line. All other robots have to move behind a line parallel to the goal line and 0.4 meters behind the penalty mark. When these constraints are met, the referee may continue with a <<ノーマルスタート/Normal Start, normal start>> command.
 
-normal startコマンドが発行されたとき、キッカーはボールをシュートすることが許可される。ペナルティキックから直接ゴールしても得点となる。 +
-When the <<Normal Start, normal start>> command is issued, the kicker is allowed to shoot the ball. A goal may be scored directly from the penalty kick.
+<<ノーマルスタート/Normal Start, normal start>>コマンドが発行されたとき、キッカーはボールをシュートすることが許可される。ペナルティキックから直接ゴールしても得点となる。 +
+When the <<ノーマルスタート/Normal Start, normal start>> command is issued, the kicker is allowed to shoot the ball. A goal may be scored directly from the penalty kick.
 
-ボールがインプレイになっているとき、キッカーは他のロボットがボールに触れるか、ゲームが停止するまでボールに触れてはいけない(ダブルタッチを参照)。また、ロボットの位置に関する制限が解除される。 +
-When the ball is <<Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
+ボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>になっているとき、キッカーは他のロボットがボールに触れるか、ゲームが停止するまでボールに触れてはいけない(「<<ダブルタッチ/Double Touch, ダブルタッチ>>」を参照)。また、ロボットの位置に関する制限が解除される。 +
+When the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<ダブルタッチ/Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
 
-ペナルティキックがハーフタイムや試合終了の時に実行される場合、アディショナルタイムが許可される。 +
+ペナルティーキックがハーフタイムや試合終了の時に実行される場合、アディショナルタイムが許可される。 +
 Additional time is allowed for a penalty kick to be taken at the end of each half or at the end of periods of overtime.
 
-攻撃側のチームがルールを侵害し、ボールがゴールに入った場合、または守備側のチームがルールを侵害し、ボールがゴールに入っていない場合、ペナルティキックは再度行われる。 +
+攻撃側のチームがルールを侵害し、ボールがゴールに入った場合、または守備側のチームがルールを侵害し、ボールがゴールに入っていない場合、ペナルティーキックは再度行われる。 +
 The penalty kick is retaken if the attacking team infringes the rules and the ball enters the goal or the defending team infringes the rules and the ball does not enter the goal.
 
 .用途/Usage
-ペナルティキックは複数のイエローカードを受け取ったチームを罰するために使用され、それ以外に非スポーツマン行為やマルチプルディフェンスを行ったときにも使用される。 +
-Penalty Kicks are used to punish teams that received multiple <<Yellow Card, yellow cards>>, as well as to punish <<Unsporting Behavior, unsporting behavior>> and <<Multiple Defenders, multiple defenders>>.
+ペナルティキックは複数の<<イエローカード/Yellow Card, イエローカード>>を受け取ったチームを罰するために使用され、それ以外に<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>や<<マルチプルディフェンス/Multiple Defenders, マルチプルディフェンス>>を行ったときにも使用される。 +
+Penalty Kicks are used to punish teams that received multiple <<イエローカード/Yellow Card, yellow cards>>, as well as to punish <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>> and <<マルチプルディフェンス/Multiple Defenders, multiple defenders>>.
 
 
 === 罰則/Sanctions
 
 ==== イエローカード/Yellow Card
 .定義/Definition
-イエローカードはハルト中の時のみ宣告される。 +
-A yellow card can only be given during <<Halt, halt>>.
+イエローカードは<<ハルト/Halt,ハルト>>中の時のみ宣告される。 +
+A yellow card can only be given during <<ハルト/Halt, halt>>.
 
-イエローカードが非スポーツマン行為の結果として示された場合、主審は直ちに試合を中断することができる。この場合、もう片方のチームの直接フリーキックで試合が継続される。 +
-If the yellow card is shown as a result of <<Unsporting Behavior, unsporting behavior>>, the referee may decide to immediately <<Halt, halt>> the match. In this case, the match continues with a direct free kick for the other team.
+イエローカードが非スポーツマン行為の結果として示された場合、主審は直ちに試合を<<ハルト/Halt, 中断>>することができる。この場合、もう片方のチームの直接フリーキックで試合が継続される。 +
+If the yellow card is shown as a result of <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>, the referee may decide to immediately <<ハルト/Halt, halt>> the match. In this case, the match continues with a direct free kick for the other team.
 
-イエローカードを受け取ると、ペナルティを受けたチームがフィールドに出場させて良いロボットの数が1台減少する。この減少のあと、チームがフィールドに出場させて良い台数よりも多くのロボットが出場している場合、試合の再開より前にロボットを退場させなければいけない。ペナルティを受けたチームは、退場させるロボットを選択することができる。 +
-Upon receipt of a yellow card, the number of robots allowed on the field for the penalized team decreases by one. If, after this decrease, the team has more robots than permitted on the field, a robot must be <<Robot Substitution, taken out>> before <<Resuming The Game, play resumes>>. The penalized team can choose the robot to remove.
+イエローカードを受け取ると、ペナルティを受けたチームがフィールドに出場させて良いロボットの数が1台減少する。この減少のあと、チームがフィールドに出場させて良い台数よりも多くのロボットが出場している場合、<<試合の再開/Resuming The Game, 試合の再開>>より前に<<ロボットの交代/Robot Substitution, ロボットを退場>>させなければいけない。ペナルティを受けたチームは、退場させるロボットを選択することができる。 +
+Upon receipt of a yellow card, the number of robots allowed on the field for the penalized team decreases by one. If, after this decrease, the team has more robots than permitted on the field, a robot must be <<ロボットの交代/Robot Substitution, taken out>> before <<試合の再開/Resuming The Game, play resumes>>. The penalized team can choose the robot to remove.
 
-(game controllerによって計測された)試合時間が120秒経過した後、イエローカードの有効期間が終了してフィールドに出場してよいロボットが1台増える。イエローカードを受けていたチームは次の機会にロボットを戻しても良い。 +
-After 120 seconds of playing time (measured by the game controller), the yellow card expires and the number of allowed robots is increased by one. The team may <<Robot Substitution, put a robot back in>> during the next opportunity.
+(game controllerによって計測された)試合時間が120秒経過した後、イエローカードの有効期間が終了してフィールドに出場してよいロボットが1台増える。イエローカードを受けていたチームは次の機会に<<ロボットの交代/Robot Substitution, ロボットを戻しても良い>>。 +
+After 120 seconds of playing time (measured by the game controller), the yellow card expires and the number of allowed robots is increased by one. The team may <<ロボットの交代/Robot Substitution, put a robot back in>> during the next opportunity.
 
-1チームにつき(そのカードの色に関係なく)3枚ごとに、1回のペナルティーキックが相手チームに与えられる。 +
-For every third card (regardless of its color) for one team, a <<Penalty Kick, penalty kick>> is awarded to the opponent team.
+1チームにつき(そのカードの色に関係なく)3枚ごとに、1回の<<ペナルティーキック/Penalty Kick, ペナルティーキック>>が相手チームに与えられる。 +
+For every third card (regardless of its color) for one team, a <<ペナルティーキック/Penalty Kick, penalty kick>> is awarded to the opponent team.
 
 .用途/Usage
-イエローカードは複数回のファウルを犯したチームを罰するために使用される。 +
-Yellow cards are used to punish teams that committed multiple <<Fouls, fouls>>.
+イエローカードは複数回の<<ファウル/Fouls, ファウル>>を犯したチームを罰するために使用される。 +
+Yellow cards are used to punish teams that committed multiple <<ファウル/Fouls, fouls>>.
 
-イエローカードはファウルや非スポーツマン行為を罰するために主審が宣告する事もできる。 +
-Yellow cards can also be given by the referee to punish <<Fouls, fouls>> or <<Unsporting Behavior,unsporting behavior>>.
+イエローカードは<<ファウル/Fouls, ファウル>>や<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>を罰するために主審が宣告する事もできる。 +
+Yellow cards can also be given by the referee to punish <<ファウル/Fouls, fouls>> or <<非スポーツマン行為/Unsporting Behavior,unsporting behavior>>.
 
 ==== レッドカード/Red Card
 .定義/Definition
-レッドカードはイエローカードと似ているが違いがある：レッドカードは試合終了まで有効期間が終了しない。 +
-A red card behaves like a <<Yellow Card, yellow card>>, exept: It does not expire until the end of the game.
+レッドカードは<<イエローカード/Yellow Card, イエローカード>>と似ているが違いがある：レッドカードは試合終了まで有効期間が終了しない。 +
+A red card behaves like a <<イエローカード/Yellow Card, yellow card>>, exept: It does not expire until the end of the game.
 
 .用途/Usage
-レッドカードはファウルや非スポーツマン行為を罰するために主審が宣告する。 +
-Red cards are given by the referee to punish severe <<Fouls, fouls>> or <<Unsporting Behavior,unsporting behavior>>.
+レッドカードは<<ファウル/Fouls, ファウル>>や<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>を罰するために主審が宣告する。 +
+Red cards are given by the referee to punish severe <<ファウル/Fouls, fouls>> or <<非スポーツマン行為/Unsporting Behavior,unsporting behavior>>.
 
 NOTE: 例えば、ロボットによる深刻な暴力的接触や審判に対する礼儀正しくない行動はレッドカードになる可能性がある。 +
 For example, serious violent contact by the robots or disrespectful behavior towards the referees can result in a red card.
@@ -257,8 +257,8 @@ A Forced forfeit means that a team instantly loses the current game with a score
 少なくとも1台の規則を満たすロボットで試合ができない場合、チームは強制的に試合を放棄させられる。 +
 A team can be forced to forfeit if it is unable to play with at least one robot that satisfies the rules.
 
-チームは技術委員会と組織委員会のメンバーと合意することによって強制的な試合放棄ができる。 +
-A team can only be forced to forfeit in agreement with members of the <<Technical Committee, technical committee>> and the <<Organizing Committee, organizing committee>>.
+チームは<<技術委員会/Technical Committee, 技術委員会>>と<<組織委員会/Organizing Committee, 組織委員会>>のメンバーと合意することによって強制的な試合放棄ができる。 +
+A team can only be forced to forfeit in agreement with members of the <<技術委員会/Technical Committee, technical committee>> and the <<組織委員会/Organizing Committee, organizing committee>>.
 
 ==== 失格/Disqualification
 .定義/Definition
@@ -269,5 +269,5 @@ A Disqualification means that a team immediately drops out of the tournament and
 チームのメンバーが安全ガイドライン、会場のルールに従わない場合、または同様の重大な違反を行う場合、チームは失格になることがある。 +
 A team can be disqualified if members of this team don't follow safety guidelines, rules of the venue or commit similarly severe offenses.
 
-チームは技術委員会と組織委員会のメンバーと合意することによって失格になることができる。 +
-A team can only be disqualified in agreement with members of the <<Technical Committee, technical committee>> and the <<Organizing Committee, organizing committee>>.
+チームは<<技術委員会/Technical Committee, 技術委員会>>と<<組織委員会/Organizing Committee, 組織委員会>>のメンバーと合意することによって失格になることができる。 +
+A team can only be disqualified in agreement with members of the <<技術委員会/Technical Committee, technical committee>> and the <<組織委員会/Organizing Committee, organizing committee>>.

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -39,7 +39,7 @@ A robot must not take full control of the ball by removing all of its degrees of
 すべての参加チームは、<<Vision, 共有Visionシステム>>による動作条件に従わなければならない。チームは標準化されたカラーとパターンをロボットの頭部にセットする必要がある。 +
 All participating teams must adhere to the given operating requirements of the <<Vision, shared vision system>>. In particular, teams are required to use a certain set of standardized colors and patterns on top of their robots.
 
-ロボットの上部の色は黒もしくはダークグレーで、照り返しがないようにしなければならない。スタンダードVisionパターンは<<standard-vision-pattern, 図5>>に.示されるように、ロボット前面側については中心から0.055mより先を接線と並行に切り落とした、半径0.085mの円形に収まらなければならない。チームはロボットの上部が完全にこの領域を囲むようにする必要がある。 +
+ロボットの上部の色は黒もしくはダークグレーで、照り返しがないようにしなければならない。スタンダードVisionパターンは<<standard-vision-pattern, 図5>>に示されるように、ロボット前面側については中心から0.055mより先を接線と並行に切り落とした、半径0.085mの円形に収まらなければならない。チームはロボットの上部が完全にこの領域を囲むようにする必要がある。 +
 To ensure compatibility with the standardized patterns for the shared vision system, all teams must ensure that all robots have a flat surface with sufficient space available on the top side. The color of the robot top must be black or dark grey and have a matte (non-shiny) finish to reduce glare. The standard vision pattern is guaranteed to fit within a circle with a radius of 0.085 meters that is linearly cut off on the front side of the robot to a distance of 0.055 meters from the centre, as shown in <<standard-vision-pattern, figure 5>>. Teams must ensure that their robot tops fully enclose this area.
 
 [[standard-vision-pattern]]
@@ -49,7 +49,7 @@ image::standard_pattern2010.png[]
 すべてのロボットは<<standard-vision-colors, 図6>>に示された16パターンのうちのひとつを持たなければならない。2台のロボットが同じ色のパターンを使用することは許可しない。 +
 Every robot must have one of the 16 patterns shown in <<standard-vision-colors, figure 6>>. No two robots are allowed to use the same pattern.
 
-センターカラーは先に述べたとおり、青か黄色のいずれかである(「<<チームカラーの選択/Choosing Team Colors, チームカラーの選択>>」も参照するように)。残りの4点の色はロボットのIDが符号化されている。<<組織委員会/Organizing Committee, 組織委員会>>はすべてのチームにおいて同じ色が使用されていることを確かめるため、十分な量の色紙を協議会において提供する。 +
+センターカラーは先に述べたとおり、青か黄色のいずれかである(「<<チームカラーの選択/Choosing Team Colors, チームカラーの選択>>」を参照)。残りの4点の色はロボットのIDが符号化されている。<<組織委員会/Organizing Committee, 組織委員会>>はすべてのチームにおいて同じ色が使用されていることを確かめるため、十分な量の色紙を協議会において提供する。 +
 The center dot color determines the team and is either blue or yellow (see <<チームカラーの選択/Choosing Team Colors, Choosing Team Colors>>). The other four dot colors encode the id of the robot. To ensure that every team uses the same colors, the <<組織委員会/Organizing Committee, organizing committee>> provides enough colored paper at the competition.
 
 NOTE: 2つのドットの間に“色にじみ”が起きる危険性があるが、 ID0から7のパターンは実験的に安定して動作することが確かめられたため、参加チームはこれらのパターンを選択することを推奨する。 +
@@ -63,7 +63,7 @@ image::standard_colors2010.png[width=500]
 無線通信を使用する参加者は、通信の方法、電力、周波数を<<組織委員会/Organizing Committee, 組織委員会>>に通知するものとする。<<組織委員会/Organizing Committee, 組織委員会>>は、登録後のいかなる変更についてもできるだけ早く通知を受けなければならない。混線を回避するために、試合の前にチームは2つの周波数から選択出来るようにしなければならない。無線通信の形式は、競技が開催される国の法的規則に従うものとする。現地の法律を守ることは、ロボカップ委員会ではなく競技するチームが責任を負うものとする。 +
 Participants using wireless communications must notify the <<組織委員会/Organizing Committee, organizing committee>> of the method of wireless communication, power, and frequency. The <<組織委員会/Organizing Committee, organizing committee>> must be notified of any change after registration as soon as possible. In order to avoid interference, a team must be able to select from two carrier frequencies before the match. The type of wireless communication has to follow legal regulations of the country where the competition is held. Compliance with local laws is the responsibility of the competing teams, not the RoboCup Federation.
 
-無線通信のタイプも地域の組織委員会により制限されることがある。<<地域の組織委員会/Local Organizing Committee, 地域の組織委員会>>はどんな制限も、できるだけ早くコミュニティーに通知すること。 +
+無線通信のタイプも<<地域の組織委員会/Local Organizing Committee, 地域の組織委員会>>地域の組織委員会により制限されることがある。地域の組織委員会はどんな制限も、できるだけ早くコミュニティーに通知すること。 +
 The type of wireless communication may also be restricted by the <<地域の組織委員会/Local Organizing Committee, local organizing committee>>. The local organizing committee will announce any restrictions to the community as early as possible.
 
 NOTE: Bluetoothによる通信は周波数チャンネルを固定にできないので禁止する。 +

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -43,7 +43,7 @@ All participating teams must adhere to the given operating requirements of the <
 To ensure compatibility with the standardized patterns for the shared vision system, all teams must ensure that all robots have a flat surface with sufficient space available on the top side. The color of the robot top must be black or dark grey and have a matte (non-shiny) finish to reduce glare. The standard vision pattern is guaranteed to fit within a circle with a radius of 0.085 meters that is linearly cut off on the front side of the robot to a distance of 0.055 meters from the centre, as shown in <<standard-vision-pattern, figure 5>>. Teams must ensure that their robot tops fully enclose this area.
 
 [[standard-vision-pattern]]
-.Standard Vision Pattern Dimensions
+.標準ビジョンパターンの寸法/Standard Vision Pattern Dimensions
 image::standard_pattern2010.png[]
 
 すべてのロボットはfigure 6に示された16パターンのうちのひとつを持たなければならない。2台のロボットが同じ色のパターンを使用することは許可しない。 +
@@ -55,7 +55,7 @@ The center dot color determines the team and is either blue or yellow (see <<Cho
 NOTE: 2つのドットの間に“色にじみ”が起きる危険性があるが、 ID0から7のパターンは実験的に安定して動作することが確かめられたため、参加チームはこれらのパターンを選択することを推奨する。 +
 Teams are encouraged to prefer color assignments with ids 0 to 7 because they have been experimentally found more stable, as there is no risk that the back two dots “color-bleed” into each other.
 
-.Standard Vision Pattern Colors
+.標準ビジョンパターンの色/Standard Vision Pattern Colors
 [[standard-vision-colors]]
 image::standard_colors2010.png[width=500]
 

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -19,7 +19,7 @@ A robot must not pose danger to itself, another robot, or humans. It must not <<
 The <<主審/Referee, referee>> has to force a team to remove a robot from the field if he considers it a potential safety threat.
 
 ==== 形状/Shape
-ロボットはいかなる時点においても、直径0.18m、高さ0.15m以下の大きさでなければならない。さらに、ロボットの上面はstandard patternが貼り付けられており、表面の制約を満たさなければいけない。 +
+ロボットはいかなる時点においても、直径0.18m、高さ0.15m以下の大きさでなければならない。さらに、ロボットの上面はstandard patternのサイズおよび表面の制約を満たさなければいけない。 +
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
 ==== ドリブルデバイス/Dribbling Device

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -1,22 +1,22 @@
 == ロボット/Robots
 
 === ロボットの台数/Number Of Robots
-試合は1台のキーパーを含んだディヴィジョンAなら8台以下、ディヴィジョンBなら6台以下のロボットを使用する2つのチームで行われる。試合中に審判がロボットを識別できるように、各ロボットにはVision pattarnに従って明確に番号が与えられていなければならない。ゴールキーパーのIDは試合が始まる前に指定されていなければならない(「ゴールキーパーのIDの選択」を参照)。 +
-A match is played by two teams, with each team consisting of not more than 8 robots in division A and not more than 6 robots in division B, one of which may be the keeper. Each robot must be clearly numbered according to its vision pattern so that the referee can identify it during the match. The id of the keeper must be chosen before the match starts (see <<Choosing Keeper Id>>).
+試合は1台のキーパーを含んだディヴィジョンAなら8台以下、ディヴィジョンBなら6台以下のロボットを使用する2つのチームで行われる。試合中に審判がロボットを識別できるように、各ロボットにはVision pattarnに従って明確に番号が与えられていなければならない。ゴールキーパーのIDは試合が始まる前に指定されていなければならない(「<<ゴールキーパーのIDの選択/Choosing Keeper Id,ゴールキーパーのIDの選択>>」を参照)。 +
+A match is played by two teams, with each team consisting of not more than 8 robots in division A and not more than 6 robots in division B, one of which may be the keeper. Each robot must be clearly numbered according to its vision pattern so that the referee can identify it during the match. The id of the keeper must be chosen before the match starts (see [<<ゴールキーパーのIDの選択/Choosing Keeper Id, Choosing Keeper ID>>]).
 
 === ハードウェアとソフトウェアの制約/Hardware And Software Constraints
-主審はチームが規則を満たさない場合には、フィールドからロボットを取り除くように強制することができる。技術委員会の委員もトーナメントのどの時点でもロボットに取り付けられるハードウェアとソフトウェアを確認することができる。 +
-The <<Referee, referee>> may force a team to remove a robot from the field if it does not satisfy the rules. Members of the <<Technical Committee, technical committee>> may also check the hardware and software constraints of robots at any point of the tournament.
+<<主審/Referee, 主審>>はチームが規則を満たさない場合には、フィールドからロボットを取り除くように強制することができる。<<技術委員会/Technical Committee, 技術委員会>>の委員もトーナメントのどの時点でもロボットに取り付けられるハードウェアとソフトウェアを確認することができる。 +
+The <<主審/Referee, referee>> may force a team to remove a robot from the field if it does not satisfy the rules. Members of the <<技術委員会/Technical Committee, technical committee>> may also check the hardware and software constraints of robots at any point of the tournament.
 
-チームがルールを満たすロボットを1台も提供できない場合、チームは強制的な試合放棄になる。 +
-If a team is not able to provide at least one robot that satisfies the rules, the team is <<Forced Forfeit, forced to forfeit>>.
+チームがルールを満たすロボットを1台も提供できない場合、チームは<<強制的な試合放棄/Forced Forfeit, 強制的な試合放棄>>になる。 +
+If a team is not able to provide at least one robot that satisfies the rules, the team is <<強制的な試合放棄/Forced Forfeit, forced to forfeit>>.
 
 ==== 安全性/Safety
-ロボットは自分自身、人間、他のロボットに対して危険な装備をしていてはならない。ボールやフィールドを損傷や変形させてはいけない。 +
-A robot must not pose danger to itself, another robot, or humans. It must not <<Damaging The Field Or The Ball, damage or modify the ball or the field>>.
+ロボットは自分自身、人間、他のロボットに対して危険な装備をしていてはならない。<<ボールやフィールドの損傷/Damaging The Field Or The Ball, ボールやフィールドを損傷や変形>>させてはいけない。 +
+A robot must not pose danger to itself, another robot, or humans. It must not <<ボールやフィールドの損傷/Damaging The Field Or The Ball, damage or modify the ball or the field>>.
 
-主審は潜在的な安全上の脅威が存在すると考えるならば、ロボットをフィールドから退場させなければならない。 +
-The <<Referee, referee>> has to force a team to remove a robot from the field if he considers it a potential safety threat.
+<<主審/Referee, 主審>>は潜在的な安全上の脅威が存在すると考えるならば、ロボットをフィールドから退場させなければならない。 +
+The <<主審/Referee, referee>> has to force a team to remove a robot from the field if he considers it a potential safety threat.
 
 ==== 形状/Shape
 ロボットはいかなる時点においても、直径0.18m、高さ0.15m以下の大きさでなければならない。さらに、ロボットの上面はstandard patternが貼り付けられており、表面の制約を満たさなければいけない。 +
@@ -36,39 +36,39 @@ A robot must not take full control of the ball by removing all of its degrees of
 80% of the area of the ball when viewed from above has to be outside the convex hull around the robot. This limitation applies as well to all kicking devices, even if such infringement is momentary.
 
 ==== Vision Pattern
-すべての参加チームは、共有Visionシステムによる動作条件に従わなければならない。チームは標準化されたカラーとパターンをロボットの頭部にセットする必要がある。 +
+すべての参加チームは、<<Vision, 共有Visionシステム>>による動作条件に従わなければならない。チームは標準化されたカラーとパターンをロボットの頭部にセットする必要がある。 +
 All participating teams must adhere to the given operating requirements of the <<Vision, shared vision system>>. In particular, teams are required to use a certain set of standardized colors and patterns on top of their robots.
 
-ロボットの上部の色は黒もしくはダークグレーで、照り返しがないようにしなければならない。スタンダードVisionパターンはfigure 5に.示されるように、ロボット前面側については中心から0.055mより先を接線と並行に切り落とした、半径0.085mの円形に収まらなければならない。チームはロボットの上部が完全にこの領域を囲むようにする必要がある。 +
+ロボットの上部の色は黒もしくはダークグレーで、照り返しがないようにしなければならない。スタンダードVisionパターンは<<standard-vision-pattern, 図5>>に.示されるように、ロボット前面側については中心から0.055mより先を接線と並行に切り落とした、半径0.085mの円形に収まらなければならない。チームはロボットの上部が完全にこの領域を囲むようにする必要がある。 +
 To ensure compatibility with the standardized patterns for the shared vision system, all teams must ensure that all robots have a flat surface with sufficient space available on the top side. The color of the robot top must be black or dark grey and have a matte (non-shiny) finish to reduce glare. The standard vision pattern is guaranteed to fit within a circle with a radius of 0.085 meters that is linearly cut off on the front side of the robot to a distance of 0.055 meters from the centre, as shown in <<standard-vision-pattern, figure 5>>. Teams must ensure that their robot tops fully enclose this area.
 
 [[standard-vision-pattern]]
-.標準ビジョンパターンの寸法/Standard Vision Pattern Dimensions
+.スタンダードVisionパターンの寸法/Standard Vision Pattern Dimensions
 image::standard_pattern2010.png[]
 
-すべてのロボットはfigure 6に示された16パターンのうちのひとつを持たなければならない。2台のロボットが同じ色のパターンを使用することは許可しない。 +
+すべてのロボットは<<standard-vision-colors, 図6>>に示された16パターンのうちのひとつを持たなければならない。2台のロボットが同じ色のパターンを使用することは許可しない。 +
 Every robot must have one of the 16 patterns shown in <<standard-vision-colors, figure 6>>. No two robots are allowed to use the same pattern.
 
-センターカラーは先に述べたとおり、青か黄色のいずれかである(チームカラーの選択も参照するように)。残りの4点の色はロボットのIDが符号化されている。組織委員会はすべてのチームにおいて同じ色が使用されていることを確かめるため、十分な量の色紙を協議会において提供する。 +
-The center dot color determines the team and is either blue or yellow (see <<Choosing Team Colors>>). The other four dot colors encode the id of the robot. To ensure that every team uses the same colors, the <<Organizing Committee, organizing committee>> provides enough colored paper at the competition.
+センターカラーは先に述べたとおり、青か黄色のいずれかである(「<<チームカラーの選択/Choosing Team Colors, チームカラーの選択>>」も参照するように)。残りの4点の色はロボットのIDが符号化されている。<<組織委員会/Organizing Committee, 組織委員会>>はすべてのチームにおいて同じ色が使用されていることを確かめるため、十分な量の色紙を協議会において提供する。 +
+The center dot color determines the team and is either blue or yellow (see <<チームカラーの選択/Choosing Team Colors, Choosing Team Colors>>). The other four dot colors encode the id of the robot. To ensure that every team uses the same colors, the <<組織委員会/Organizing Committee, organizing committee>> provides enough colored paper at the competition.
 
 NOTE: 2つのドットの間に“色にじみ”が起きる危険性があるが、 ID0から7のパターンは実験的に安定して動作することが確かめられたため、参加チームはこれらのパターンを選択することを推奨する。 +
 Teams are encouraged to prefer color assignments with ids 0 to 7 because they have been experimentally found more stable, as there is no risk that the back two dots “color-bleed” into each other.
 
-.標準ビジョンパターンの色/Standard Vision Pattern Colors
+.スタンダードVisionパターンの色/Standard Vision Pattern Colors
 [[standard-vision-colors]]
 image::standard_colors2010.png[width=500]
 
 ==== 無線通信/Radio Communication
-無線通信を使用する参加者は、通信の方法、電力、周波数を組織委員会に通知するものとする。組織委員会は、登録後のいかなる変更についてもできるだけ早く通知を受けなければならない。混線を回避するために、試合の前にチームは2つの周波数から選択出来るようにしなければならない。無線通信の形式は、競技が開催される国の法的規則に従うものとする。現地の法律を守ることは、ロボカップ委員会ではなく競技するチームが責任を負うものとする。 +
-Participants using wireless communications must notify the <<Organizing Committee, organizing committee>> of the method of wireless communication, power, and frequency. The <<Organizing Committee, organizing committee>> must be notified of any change after registration as soon as possible. In order to avoid interference, a team must be able to select from two carrier frequencies before the match. The type of wireless communication has to follow legal regulations of the country where the competition is held. Compliance with local laws is the responsibility of the competing teams, not the RoboCup Federation.
+無線通信を使用する参加者は、通信の方法、電力、周波数を<<組織委員会/Organizing Committee, 組織委員会>>に通知するものとする。<<組織委員会/Organizing Committee, 組織委員会>>は、登録後のいかなる変更についてもできるだけ早く通知を受けなければならない。混線を回避するために、試合の前にチームは2つの周波数から選択出来るようにしなければならない。無線通信の形式は、競技が開催される国の法的規則に従うものとする。現地の法律を守ることは、ロボカップ委員会ではなく競技するチームが責任を負うものとする。 +
+Participants using wireless communications must notify the <<組織委員会/Organizing Committee, organizing committee>> of the method of wireless communication, power, and frequency. The <<組織委員会/Organizing Committee, organizing committee>> must be notified of any change after registration as soon as possible. In order to avoid interference, a team must be able to select from two carrier frequencies before the match. The type of wireless communication has to follow legal regulations of the country where the competition is held. Compliance with local laws is the responsibility of the competing teams, not the RoboCup Federation.
 
-無線通信のタイプも地域の組織委員会により制限されることがある。地域の組織委員会はどんな制限も、できるだけ早くコミュニティーに通知すること。 +
-The type of wireless communication may also be restricted by the <<Local Organizing Committee, local organizing committee>>. The local organizing committee will announce any restrictions to the community as early as possible.
+無線通信のタイプも地域の組織委員会により制限されることがある。<<地域の組織委員会/Local Organizing Committee, 地域の組織委員会>>はどんな制限も、できるだけ早くコミュニティーに通知すること。 +
+The type of wireless communication may also be restricted by the <<地域の組織委員会/Local Organizing Committee, local organizing committee>>. The local organizing committee will announce any restrictions to the community as early as possible.
 
 NOTE: Bluetoothによる通信は周波数チャンネルを固定にできないので禁止する。 +
 Bluetooth is not allowed since it cannot be fixed to frequency channels.
 
 ==== 自律性/Autonomy
-ロボットの装備は完全に自律していなくてはならない。試合中、人間のオペレーターは、breaksやtimeout中以外に、システムに対して一切の情報を入力することはできない。このルールを無視することは、非スポーツマン行為とみなす。 +
-The robotic equipment has to be fully autonomous. Human operators are not permitted to enter any information to the system during a match, except in <<Overview, breaks>> or during a <<Timeouts,timeout>>. Disregarding this rule is considered <<Unsporting Behavior, unsporting behavior>>.
+ロボットの装備は完全に自律していなくてはならない。試合中、人間のオペレーターは、<<概要/Overview, 休憩>>や<<タイムアウト/Timeouts, タイムアウト>>中以外に、システムに対して一切の情報を入力することはできない。このルールを無視することは、<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>とみなす。 +
+The robotic equipment has to be fully autonomous. Human operators are not permitted to enter any information to the system during a match, except in <<概要/Overview, breaks>> or during a <<タイムアウト/Timeouts, timeout>>. Disregarding this rule is considered <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>.

--- a/chapters/scoringgoals.adoc
+++ b/chapters/scoringgoals.adoc
@@ -5,13 +5,13 @@ A goal is scored if the ball enters the goal between the goal posts, provided th
 さらに、ゴールは以下の場合のみ有効である。 +
 Additionally, the goal is only valid if
 
-* 間接フリーキックから直接ゴールにシュートされていない。 +
-It is not shot directly from an <<Indirect Free Kick, indirect free kick>>
+* <<間接フリーキック/Indirect Free Kick, 間接フリーキック>>から直接ゴールにシュートされていない。 +
+It is not shot directly from an <<間接フリーキック/Indirect Free Kick, indirect free kick>>
 * アタッカーが最後にボールに触れてから、ボールの高さが0.15mを超えていない +
 The height of the ball did not exceed 0.15 meters after the last touch of an attacker
 
-NOTE: シュートアウト中は、これらの追加ルールは適用されない。 +
-During <<Shoot-Out, shoot-out>>, these additional rules do not apply.
+NOTE: <<シュートアウト/Shoot-Out, シュートアウト>>中は、これらの追加ルールは適用されない。 +
+During <<シュートアウト/Shoot-Out, shoot-out>>, these additional rules do not apply.
 
 ゴールが無効とみなされた場合、試合はボールがゴールの外側のゴールラインを交差したものとして継続する。 +
 If the goal is considered invalid, the game will be continued as if the ball crossed the goal line outside the goal.

--- a/chapters/shootout.adoc
+++ b/chapters/shootout.adoc
@@ -3,49 +3,49 @@
 両チームが交互にゴールに得点を決めようと各チームそれぞれ5回のシュートを試行する。もし両チームとも5回の試行が終わった時に同点であった場合、2チームの得点が異なるまで前と同じ順番でさらに試行回数を増やす。 +
 Both teams alternately attempt to score a goal until each team has performed 5 attempts. If both teams have the same score after those 5 attempts, each team takes another attempt in the same order as before until the score of the two teams is different.
 
-各チームには1台の攻撃ロボットと1台のキーパーだけが許可される。シュートアウトの間、攻撃ロボットと相手のキーパーだけがボールの操作と移動ができる。他のロボットは干渉してはいけない。 +
-Only one attacking robot and one keeper is allowed per team. During a shoot-out attempt, the attacking robot and the opponent keeper are the only ones allowed to move and <<Ball Manipulation, manipulate the ball>>. Other robots are not allowed to interfere.
+各チームには1台の攻撃ロボットと1台のキーパーだけが許可される。シュートアウトの間、攻撃ロボットと相手のキーパーだけが<<ボールの操作/Ball Manipulation, ボールの操作>>と移動ができる。他のロボットは干渉してはいけない。 +
+Only one attacking robot and one keeper is allowed per team. During a shoot-out attempt, the attacking robot and the opponent keeper are the only ones allowed to move and <<ボールの操作/Ball Manipulation, manipulate the ball>>. Other robots are not allowed to interfere.
 
 シュートアウトの手順は以下である: +
 The procedure of a shoot-out attempt is as follows:
 
-. ボールは相手のゴールから(ディヴィジョンAなら)8mか(ディヴィジョンBなら)6mの位置にあるミッドライン(ハーフウェイラインではない)に人間の審判によって置かれる。 +
-The ball is placed by the human referee on the <<Additional Lines, mid-line>> (not halfway line), 8 meters (division A) or 6 meters (division B) away from the opponent goal.
-. ペナルティーキックのコマンドが発行されたとき、守備側チームのキーパーはゴールラインに移動し、ラインに触れ続けなければならない +
-When the <<Penalty Kick, penalty>> command is issued, the defending keeper has to move to the goal line and keep touching it.
-. normal startのコマンドが発行されたとき、アタッカーはボールを操作することが許可される。ボールは相手ゴールに向かって動かさなければならない。これは、SSL-Visionの座標系におけるx座標によって測定されている。 +
-When the <<Normal Start, normal start>> command is issued, the attacker is allowed to <<Ball Manipulation, manipulate the ball>>. The ball has to only move towards the opponent goal, as measured by its x coordinate in the coordinate system of <<Vision, SSL-Vision>>.
-. ボールがインプレイになった時、守備側チームのキーパはペナルティキックと同じように再び自由に動いてよい。 +
-When the ball is <<Ball In And Out Of Play, in play>>, the defending keeper may move freely again, analogous to a <<Penalty Kick, penalty kick>>.
+. ボールは相手のゴールから(ディヴィジョンAなら)8mか(ディヴィジョンBなら)6mの位置にある<<追加のライン/Additional Lines, ミッドライン>>(ハーフウェイラインではない)に人間の審判によって置かれる。 +
+The ball is placed by the human referee on the <<追加のライン/Additional Lines, mid-line>> (not halfway line), 8 meters (division A) or 6 meters (division B) away from the opponent goal.
+. <<ペナルティーキック/Penalty Kick, ペナルティーキック>>のコマンドが発行されたとき、守備側チームのキーパーはゴールラインに移動し、ラインに触れ続けなければならない +
+When the <<ペナルティーキック/Penalty Kick, penalty>> command is issued, the defending keeper has to move to the goal line and keep touching it.
+. <<ノーマルスタート/Normal Start, ノーマルスタート>>のコマンドが発行されたとき、アタッカーは<<ボールの操作/Ball Manipulation, ボールを操作する>>ことが許可される。ボールは相手ゴールに向かって動かさなければならない。これは、SSL-Visionの座標系におけるx座標によって測定されている。 +
+When the <<ノーマルスタート/Normal Start, normal start>> command is issued, the attacker is allowed to <<ボールの操作/Ball Manipulation, manipulate the ball>>. The ball has to only move towards the opponent goal, as measured by its x coordinate in the coordinate system of <<Vision, SSL-Vision>>.
+. ボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>になった時、守備側チームのキーパは<<ペナルティーキック/Penalty Kick,  ペナルティキック>>と同じように再び自由に動いてよい。 +
+When the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the defending keeper may move freely again, analogous to a <<ペナルティーキック/Penalty Kick, penalty kick>>.
 
 以下の場合に得点が与えられる: +
 A goal is awarded if:
 
-* normal startのコマンドが発行されてから10秒以内に守備側チームのゴールの地面もしくはゴールウォールの内面にボールが接触した。 +
-the ball touches the inner surface of a goal wall or the ground of the goal of the defending team in less than 10 seconds, starting from when the <<Normal Start, normal start>> command is issued
+* <<ノーマルスタート/Normal Start, ノーマルスタート>>のコマンドが発行されてから10秒以内に守備側チームのゴールの地面もしくはゴールウォールの内面にボールが接触した。 +
+the ball touches the inner surface of a goal wall or the ground of the goal of the defending team in less than 10 seconds, starting from when the <<ノーマルスタート/Normal Start, normal start>> command is issued
 * 守備側チームがいかなる違反も犯していない +
 the defending team violates any rule
 
 以下の場合に得点が与えられない: +
 A goal is not awarded if:
 
-* ボールがゴールより外側のいずれかのフィールドラインを横切った +
-the ball crosses any <<Field Lines, field lines>> outside the goal
+* ボールがゴールより外側のいずれかの<<フィールドライン/Field Lines, フィールドライン>>を横切った +
+the ball crosses any <<フィールドライン/Field Lines, field lines>> outside the goal
 * 守備側チームのキーパーが2次元空間内で少なくとも90°以上ボールの速度ベクトルを変えるようにボールに触れる +
 the defending keeper touches the ball such that the ball speed vector changes direction by at least 90 degrees in 2D space
 * 攻撃側チームが何らかの違反を犯した +
 the attacking team violates any rule
 
-NOTE: ゴールの得点のために定義された制限はここでは適用されない。これには0.15mのボールの高さ制限も含まれる。例えばドリブルの超過なども該当する。 +
-The restrictions defined for <<Scoring Goals, scoring goals>> do not apply here. This explicitly includes the ball height limit of 0.15 meters. Other rules like the <<Excessive Dribbling, excessive dribbling>> limitation for example do.
+NOTE: <<ゴールの得点方法/Scoring Goals, ゴールの得点>>のために定義された制限はここでは適用されない。これには0.15mのボールの高さ制限も含まれる。例えば<<ドリブルの超過/Excessive Dribbling, ドリブルの超過>>なども該当する。 +
+The restrictions defined for <<ゴールの得点方法/Scoring Goals, scoring goals>> do not apply here. This explicitly includes the ball height limit of 0.15 meters. Other rules like the <<ドリブルの超過/Excessive Dribbling, excessive dribbling>> limitation for example do.
 
-ロボットはシュートアウトの間に交代してもよい。新しいロボットを即時入れても良い。 +
-Robots may be <<Robot Substitution, substituted>> between shoot-out attempts. The new robot may be put in right away.
+ロボットはシュートアウトの間に<<ロボットの交代/Robot Substitution, 交代>>してもよい。新しいロボットを即時入れても良い。 +
+Robots may be <<ロボットの交代/Robot Substitution, substituted>> between shoot-out attempts. The new robot may be put in right away.
 
-NOTE: シュートアウト中はタイムアウトは許可されていない事に注意する事。 +
-Note that <<Timeouts, timeouts>> are not allowed during shoot-out.
+NOTE: シュートアウト中は<<タイムアウト/Timeouts, タイムアウト>>は許可されていない事に注意する事。 +
+Note that <<タイムアウト/Timeouts, timeouts>> are not allowed during shoot-out.
 
 .用途/Usage
-シュートアウトは直前のゲームステージで両チームが同じ点の場合に、勝ち抜き戦の勝者を決定するために使用される。 +
-Shoot-Out is used to determine the winner of an elimination match if both teams scored the same amount of goals in previous <<Game Stages, game stages>>.
+シュートアウトは直前の<<ゲームステージ/Game Stages, ゲームステージ>>で両チームが同じ点の場合に、勝ち抜き戦の勝者を決定するために使用される。 +
+Shoot-Out is used to determine the winner of an elimination match if both teams scored the same amount of goals in previous <<ゲームステージ/Game Stages, game stages>>.
 

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -1,22 +1,22 @@
 == ロボットの交代/Robot Substitution
 .定義/Definition
-ロボットはそれぞれのチームのハンドラによって交代される。他のいかなるチームメンバもロボットを出し入れすることは許可されない。 +
-Robots are substituted by the <<Robot Handler, robot handler>> of the respective team. No other team member is allowed to take robots out or put robots in.
+ロボットはそれぞれのチームの<<ハンドラ/Robot Handler, ハンドラ>>によって交代される。他のいかなるチームメンバもロボットを出し入れすることは許可されない。 +
+Robots are substituted by the <<ハンドラ/Robot Handler, robot handler>> of the respective team. No other team member is allowed to take robots out or put robots in.
 
-. ロボットの交代のためにチームが指定したハンドラは、以下の動作の少なくとも1つを所定の順序で実行する。 +
-A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
+. ロボットの交代のためにチームが指定した<<ハンドラ/Robot Handler, ハンドラ>>は、以下の動作の少なくとも1つを所定の順序で実行する。 +
+A <<ハンドラ/Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
 .. ロボットを中に置く。チームがフィールド上においてよい最大数を超えてはいけない。 +
 Put robots in. The maximum allowed number of robots of the team on the field must not be exceeded.
 .. ロボットを取り除く。取り除かれたロボットがハーフウェイラインとタッチラインの交点から1m以内の距離にいる場合、別のロボットをすぐに置くことができる。それ以外の場合はハンドラーは次の機会を待たなければならない。 +
 Take robots out. If a robot that is taken out is closer than 1 meter to the intersection of the halfway line with one of the touch lines, another robot can be put in right away. Otherwise the robot handler has to wait until the next substitution opportunity.
-. 取り除かれたロボットのうち1台がキーパーだった場合、ハンドラはgame controller operatorにキーパーの役割を引き継ぐロボットのIDを伝える。 +
-If one of the robots taken out is the keeper, the <<Robot Handler, robot handler>> tells the <<Game Controller Operator, game controller operator>> the id of the robot that takes over the keeper role.
-. ハンドラは交代が完了したら主審に連絡する +
-The <<Robot Handler, robot handler>> informs the <<Referee, referee>> when done.
-. 両チームともロボットの交代が終わったら、主審はgame controller operatorに連絡する。 +
-When both teams finished the robot substitution, the <<Referee, referee>> informs the <<Game Controller Operator, game controller operator>>.
-. game controller operatorは試合を続行するためにstopコマンドを実行する。 +
-The <<Game Controller Operator, game controller operator>> performs a <<Stop, stop>> followed by continuing the game.
+. 取り除かれたロボットのうち1台がキーパーだった場合、<<ハンドラ/Robot Handler, ハンドラ>>は<<Game Controller Operator, game controller operator>>にキーパーの役割を引き継ぐロボットのIDを伝える。 +
+If one of the robots taken out is the keeper, the <<ハンドラ/Robot Handler, robot handler>> tells the <<Game Controller Operator, game controller operator>> the id of the robot that takes over the keeper role.
+. <<ハンドラ/Robot Handler, ハンドラ>>は交代が完了したら<<主審/Referee, 主審>>に連絡する +
+The <<ハンドラ/Robot Handler, robot handler>> informs the <<主審/Referee, referee>> when done.
+. 両チームともロボットの交代が終わったら、<<主審/Referee, 主審>>は<<Game Controller Operator, game controller operator>>に連絡する。 +
+When both teams finished the robot substitution, the <<主審/Referee, referee>> informs the <<Game Controller Operator, game controller operator>>.
+. <<Game Controller Operator, game controller operator>>は試合を続行するために<<停止/Stop, stop>>コマンドを実行する。 +
+The <<Game Controller Operator, game controller operator>> performs a <<停止/Stop, stop>> followed by continuing the game.
 
 .用途/Usage
 いかなる理由であってもロボットの交代ができる。交代の回数に制限はない。 +
@@ -25,15 +25,15 @@ Robots can be substituted for any reason. There is no limit on the number of sub
 ロボットの交代の意思表示は次のようにして行う： +
 A robot substitution intent can be made by:
 
-. ハンドラはgame controllerへ意図を入力するgame controller operatorに通知する。 +
-A <<Robot Handler, robot handler>> by informing the <<Game Controller Operator, game controller operator>> who in turn enters the intent into the <<Game Controller, game controller>>.)
-. チームのソフトウェアはgame controllerへリクエストを送信する。 +
+. <<ハンドラ/Robot Handler, ハンドラ>>は<<Game Controller, game controller>>へ意図を入力する<<Game Controller Operator, game controller operator>>に通知する。 +
+A <<ハンドラ/Robot Handler, robot handler>> by informing the <<Game Controller Operator, game controller operator>> who in turn enters the intent into the <<Game Controller, game controller>>.)
+. チームのソフトウェアは<<Game Controller, game controller>>へリクエストを送信する。 +
 A team software by sending a request to the <<Game Controller, game controller>>.
-. game controllerは当該チームに許された最大ロボット数を超えていないかを確認し(例えばチームがイエローかレッドカードを受け取ったあと等)、リクエストを処理する。 +
-The <<Game Controller, game controller>> itself if a team exceeds the maximum number of robots (for example after a team receives a <<Yellow Card, yellow>> or <<Red Card, red card>>).
+. <<Game Controller, game controller>>は当該チームに許された最大ロボット数を超えていないかを確認し(例えばチームが<<イエローカード/Yellow Card, イエロー>>か<<レッドカード/Red Card, レッドカード>>を受け取ったあと等)、リクエストを処理する。 +
+The <<Game Controller, game controller>> itself if a team exceeds the maximum number of robots (for example after a team receives a <<イエローカード/Yellow Card, yellow>> or <<レッドカード/Red Card, red card>>).
 
 片方のチームの交代の意図のために試合がHaltにされた場合、このチームが少なくとも1台は(ロボットを取り除くか置くかして)交代しなければならない。交代のために試合がHaltされていない場合に限り交代の意図を取り消すことができる。 +
 If the game was halted due to a substitution intent by a team, at least one substitution (taking a robot out or putting one in) must be performed by this team. A substitution intent can be revoked unless the game was not already halted for substitution.
 
-ボール配置後、試合が継続する直前にどちらかのチームがロボットを交代する意思がある場合、game controllerは自動的に試合をハルトする。 +
-If a robot substitution intent for either team is present just before the game would continue after ball placement, the <<Game Controller, game controller>> automatically <<Halt, halts>> the game.
+ボール配置後、試合が継続する直前にどちらかのチームがロボットを交代する意思がある場合、<<Game Controller, game controller>>は自動的に試合を<<ハルト/Halt, ハルト>>する。 +
+If a robot substitution intent for either team is present just before the game would continue after ball placement, the <<Game Controller, game controller>> automatically <<ハルト/Halt, halts>> the game.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -7,7 +7,7 @@ Robots are substituted by the <<ハンドラ/Robot Handler, robot handler>> of t
 A <<ハンドラ/Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
 .. ロボットを中に置く。チームがフィールド上においてよい最大数を超えてはいけない。 +
 Put robots in. The maximum allowed number of robots of the team on the field must not be exceeded.
-.. ロボットを取り除く。取り除かれたロボットがハーフウェイラインとタッチラインの交点から1m以内の距離にいる場合、別のロボットをすぐに置くことができる。それ以外の場合はハンドラーは次の機会を待たなければならない。 +
+.. ロボットを取り除く。取り除かれたロボットがハーフウェイラインとタッチラインの交点から1m以内の距離にいる場合、別のロボットをすぐに置くことができる。それ以外の場合はハンドラは次の機会を待たなければならない。 +
 Take robots out. If a robot that is taken out is closer than 1 meter to the intersection of the halfway line with one of the touch lines, another robot can be put in right away. Otherwise the robot handler has to wait until the next substitution opportunity.
 . 取り除かれたロボットのうち1台がキーパーだった場合、<<ハンドラ/Robot Handler, ハンドラ>>は<<Game Controller Operator, game controller operator>>にキーパーの役割を引き継ぐロボットのIDを伝える。 +
 If one of the robots taken out is the keeper, the <<ハンドラ/Robot Handler, robot handler>> tells the <<Game Controller Operator, game controller operator>> the id of the robot that takes over the keeper role.

--- a/sslrules.adoc
+++ b/sslrules.adoc
@@ -17,6 +17,8 @@ endif::basebackend-html[]
 NOTE: ルールにおける審判、チームメンバー、運営その他への男性称の使用は単純化のためであり、性別を問わず適用される。 +
 References to the male gender in the rules with respect to referees, team members, officials, etc. are for simplification and apply to both males and females.
 
+<<<
+
 include::chapters/introduction.adoc[]
 
 include::chapters/playingenvironment.adoc[]


### PR DESCRIPTION
## 概要

機能していないハイパーリンクの修正

## 現状

鮫島さんの翻訳の取り込み(#1)までは完了しましたが、依然としてハイパーリンクが機能していません。原因として、タイトル等が変更されているにもかかわらず、リンクのためのターゲットが翻訳されていないためです。  

例

- (asciidoc) : 
  - Title of example A
    - content of example A
  - Title of exmaple B
    - content of example B and <<Title of example A, reference for example A>>

鮫島さんの翻訳

 - (asciidoc) : 
  - 例Aのタイトル/Title of example A
    - 例Aのコンテンツ
      content of example A
  - 例Bのタイトル/Title of exmaple B
    - 例Bのコンテンツと例Aへの参照
      content of example B and <<Title of example A, reference for example A>> <-ここが変更されていないためリンクが効かない

## タスク

ということで、これを

- 日本語での表示部分 : <<例Aのタイトル/Title of example A, 例Aのタイトル>>
- 英語での表示部分 : <<例Aのタイトル/Title of example A, Title of example A>>

というふうに書き直す作業を行います。  
英語部分に関しては単純な置換でどうにかなるかと思われますが、日本語部分については手動でチェックを行いながらのリンク作成作業となります。  

加えて、いくつか見つかっている翻訳漏れやミスについては、多くがルール名に関連している(=ハイパーリンクを作成する際に影響する)ため、このPRにてまとめて修正してしまう予定です。