### PR TITLE
index.htmlからのリダイレクトの修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,6 @@
 		<meta http-equiv="refresh" content="0; url=/ssl-rules/sslrules.html" />
 	</head>
 	<body>
-		<p><a href="/ssl-rules/sslrules.html">Redirect</a></p>
+		<p><a href="/ssl-rules-jp/sslrules.html">Redirect</a></p>
 	</body>
 </html>


### PR DESCRIPTION
related : kkimurak/ssl-rules-ja#4 

github-pageで/ssl-rules-jp/index.htmlが呼ばれた際、誤って/ssl-rules/sslrules.htmlが呼ばれる不具合を修正