### PR TITLE
[gh-page] デフォルトのindex.htmlからのリダイレクトリンクの修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,6 @@
 		<meta http-equiv="refresh" content="0; url=/ssl-rules/sslrules.html" />
 	</head>
 	<body>
-		<p><a href="/ssl-rules/sslrules.html">Redirect</a></p>
+		<p><a href="/ssl-rules-jp/sslrules.html">Redirect</a></p>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<meta http-equiv="refresh" content="0; url=/ssl-rules/sslrules.html" />
+		<meta http-equiv="refresh" content="0; url=/ssl-rules-jp/sslrules.html" />
 	</head>
 	<body>
 		<p><a href="/ssl-rules-jp/sslrules.html">Redirect</a></p>


### PR DESCRIPTION
related kkimurak/ssl-rules-ja#4 (but not close)
travisでpdfを生成云々する以前の問題で、GitHubページ(/ssl-rules-jp/index.html)からルール(ssl-rules-jp/sslrules.html)へのリダイレクトリンクが間違っていました。  
htmlに記述されたリンク、およびリダイレクト設定を修正しています。