### PR TITLE
travisビルドを日本語に対応したPDFを生成するように変更

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ services:
 
 before_install:            
   - mkdir -p output
-  - docker pull asciidoctor/docker-asciidoctor
+  - docker pull htakeuchi/docker-asciidoctor-jp
 
 script:
-  - docker run -v $TRAVIS_BUILD_DIR:/documents/ asciidoctor/docker-asciidoctor asciidoctor sslrules.adoc
-  - docker run -v $TRAVIS_BUILD_DIR:/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf sslrules.adoc
+  - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor sslrules.adoc
+  - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor-pdf sslrules.adoc
 
 after_error: 
   - docker logs asciidoc-to-html

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 
 script:
   - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor sslrules.adoc
-  - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor-pdf sslrules.adoc
+  - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP sslrules.adoc
 
 after_error: 
   - docker logs asciidoc-to-html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-if: branch = master
+if: branch = master-jp
 
 sudo: required
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the AsciiDoc source for the official RoboCup Small Size League rules.
 The legacy version of the rules can be found at https://github.com/RoboCup-SSL/ssl-rules-legacy
 
 ## Build
-The rules are automatically built on updates to the master branch and published to [Github Pages](https://robocup-ssl.github.io/ssl-rules/sslrules.html). There is also a [PDF-version](https://robocup-ssl.github.io/ssl-rules/sslrules.pdf).
+The rules are automatically built on updates to the master branch and published to [Github Pages](https://kkimurak.github.io/ssl-rules-jp/sslrules.html). There is also a [PDF-version](https://kkimurak.github.io/ssl-rules-jp/sslrules.pdf).
 
 ### Using AsciiDoctor natively
 Install AsciiDoctor on your system (https://asciidoctor.org/). Afterwards, build HTML5 version with

--- a/README.md
+++ b/README.md
@@ -11,17 +11,20 @@ Install AsciiDoctor on your system (https://asciidoctor.org/). Afterwards, build
 ```
 # Build the HTML5 version
 asciidoctor sslrules.adoc
+```
+
+To build PDF version with Japanese charactors, you can use asciidoctor-pdf-cjk-kai_gen_gothic.
 # Build the PDF version
-asciidoctor-pdf sslrules.adoc
+asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP sslrules.adoc
 ```
 
 ### Using docker image
-If you have Docker installed, you can use the official AsciiDoctor image:
+If you have Docker installed, you can use the AsciiDoctor image that optimized for Japanese:
 ```
 # Pull image once
-docker pull asciidoctor/docker-asciidoctor
+docker pull htakeuchi/docker-asciidoctor-jp
 # Build the HTML5 version
 docker run -v $PWD:/documents/ asciidoctor/docker-asciidoctor asciidoctor sslrules.adoc
 # Build the PDF version
-docker run -v $PWD:/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf sslrules.adoc
+docker run -v $PWD:/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdfasciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP sslrules.adoc
 ```


### PR DESCRIPTION
closes kkimurak/ssl-rules-ja#4  
related kkimurak/ssl-rules-ja#4 kkimurak/ssl-rules-ja_archived#7  

