### PR TITLE
日本語版READMEの作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ asciidoctor sslrules.adoc
 ```
 
 To build PDF version with Japanese charactors, you can use asciidoctor-pdf-cjk-kai_gen_gothic.
+```
 # Build the PDF version
 asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP sslrules.adoc
 ```

--- a/README.md
+++ b/README.md
@@ -3,28 +3,34 @@
 English | [Japanese](README_jp.md)
 
 This is the AsciiDoc source for the unofficial Japanese translation of RoboCup Small Size League rules.  
-The official rules can be found at https://github.com/RoboCup-SSL/ssl-rules
-The legacy version of the rules can be found at https://github.com/RoboCup-SSL/ssl-rules-legacy
+The official rules can be found at [Official GitHub Repository](https://github.com/RoboCup-SSL/ssl-rules)
+The legacy version of the rules can be found at [here](https://github.com/RoboCup-SSL/ssl-rules-legacy)
 
 ## Build
+
 The rules are automatically built on updates to the master-jp branch and published to [Github Pages](https://kkimurak.github.io/ssl-rules-jp/sslrules.html). There is also a [PDF-version](https://kkimurak.github.io/ssl-rules-jp/sslrules.pdf).
 
 ### Using AsciiDoctor natively
-Install AsciiDoctor on your system (https://asciidoctor.org/). Afterwards, build HTML5 version with
-```
+
+Install [AsciiDoctor](https://asciidoctor.org/) on your system . Afterwards, build HTML5 version with
+
+```sh
 # Build the HTML5 version
 asciidoctor sslrules.adoc
 ```
 
 To build PDF version with Japanese charactors, you can use asciidoctor-pdf-cjk-kai_gen_gothic.
-```
+
+```sh
 # Build the PDF version
 asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP sslrules.adoc
 ```
 
 ### Using docker image
+
 If you have Docker installed, you can use the AsciiDoctor image that optimized for Japanese:
-```
+
+```sh
 # Pull image once
 docker pull htakeuchi/docker-asciidoctor-jp
 # Build the HTML5 version

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 English | [Japanese](README_jp.md)
 
-This is the AsciiDoc source for the official RoboCup Small Size League rules.
+This is the AsciiDoc source for the unofficial Japanese translation of RoboCup Small Size League rules.  
+The official rules can be found at https://github.com/RoboCup-SSL/ssl-rules
 The legacy version of the rules can be found at https://github.com/RoboCup-SSL/ssl-rules-legacy
 
 ## Build
-The rules are automatically built on updates to the master branch and published to [Github Pages](https://kkimurak.github.io/ssl-rules-jp/sslrules.html). There is also a [PDF-version](https://kkimurak.github.io/ssl-rules-jp/sslrules.pdf).
+The rules are automatically built on updates to the master-jp branch and published to [Github Pages](https://kkimurak.github.io/ssl-rules-jp/sslrules.html). There is also a [PDF-version](https://kkimurak.github.io/ssl-rules-jp/sslrules.pdf).
 
 ### Using AsciiDoctor natively
 Install AsciiDoctor on your system (https://asciidoctor.org/). Afterwards, build HTML5 version with

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RoboCup Small Size League rules
 
+English | [Japanese](README_jp.md)
+
 This is the AsciiDoc source for the official RoboCup Small Size League rules.
 The legacy version of the rules can be found at https://github.com/RoboCup-SSL/ssl-rules-legacy
 

--- a/README_jp.md
+++ b/README_jp.md
@@ -1,0 +1,34 @@
+# ロボカップ小型機リーグルール
+
+ロボカップ小型機リーグ(SSL)公式ルールの、AsciiDoc形式のソースコードです。  
+旧バージョンのルール(英語)は https://github.com/RoboCup-SSL/ssl-rules-legacy よりご覧いただけます。
+
+## ビルド
+
+ルールはmaster-jpブランチの更新に応じて、自動的に[Github Page](https://kkimurak.github.io/ssl-rules-jp/sslrules.html)に公開されます。[PDF版](https://kkimurak.github.io/ssl-rules-jp/sslrules.pdf)もご利用いただけます。
+
+### ネイティブ版AsciDoctorの使用
+
+AsciiDoctorをインストールしてください(https://asciidoctor.org/)。その後、以下のコマンドでHTML5版をビルドできます :
+```
+# HTML5版のビルド
+asciidoctor sslrules.adoc
+```
+
+日本語を含むPDFを生成する場合、asciidoctor-pdf-cjk-kai_gen_gothicを使うと良いでしょう :
+```
+# Build the PDF version
+asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP sslrules.adoc
+```
+
+### dockerイメージの使用
+
+Dockerをインストールしているのであれば、日本語環境向けに最適化されたAsciiDoctorイメージを使うことができます :
+```
+# dockerイメージをpullする
+docker pull htakeuchi/docker-asciidoctor-jp
+# HTML5版のビルド
+docker run -v $PWD:/documents/ asciidoctor/docker-asciidoctor asciidoctor sslrules.adoc
+# Build the PDF version
+docker run -v $PWD:/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdfasciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP sslrules.adoc
+```

--- a/README_jp.md
+++ b/README_jp.md
@@ -2,7 +2,8 @@
 
 [English](README.md) | Japanese  
 
-ロボカップ小型機リーグ(SSL)公式ルールの、AsciiDoc形式のソースコードです。  
+ロボカップ小型機リーグ(SSL)ルールの非公式日本語訳の、AsciiDoc形式のソースコードです。  
+公式ルールは https://github.com/RoboCup-SSL/ssl-rules よりご覧いただけます。
 旧バージョンのルール(英語)は https://github.com/RoboCup-SSL/ssl-rules-legacy よりご覧いただけます。
 
 ## ビルド

--- a/README_jp.md
+++ b/README_jp.md
@@ -3,8 +3,8 @@
 [English](README.md) | Japanese  
 
 ロボカップ小型機リーグ(SSL)ルールの非公式日本語訳の、AsciiDoc形式のソースコードです。  
-公式ルールは https://github.com/RoboCup-SSL/ssl-rules よりご覧いただけます。
-旧バージョンのルール(英語)は https://github.com/RoboCup-SSL/ssl-rules-legacy よりご覧いただけます。
+公式ルールは、[小型機リーグ公式GitHubリポジトリ](https://github.com/RoboCup-SSL/ssl-rules)よりご覧いただけます。
+旧バージョンのルール(英語)は[こちら](https://github.com/RoboCup-SSL/ssl-rules-legacy)よりご覧いただけます。
 
 ## ビルド
 
@@ -12,14 +12,16 @@
 
 ### ネイティブ版AsciDoctorの使用
 
-AsciiDoctorをインストールしてください(https://asciidoctor.org/)。その後、以下のコマンドでHTML5版をビルドできます :
-```
+[AsciiDoctor](https://asciidoctor.org/)をインストールしてください。その後、以下のコマンドでHTML5版をビルドできます :
+
+```sh
 # HTML5版のビルド
 asciidoctor sslrules.adoc
 ```
 
 日本語を含むPDFを生成する場合、asciidoctor-pdf-cjk-kai_gen_gothicを使うと良いでしょう :
-```
+
+```sh
 # Build the PDF version
 asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP sslrules.adoc
 ```
@@ -27,7 +29,8 @@ asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJ
 ### dockerイメージの使用
 
 Dockerをインストールしているのであれば、日本語環境向けに最適化されたAsciiDoctorイメージを使うことができます :
-```
+
+```sh
 # dockerイメージをpullする
 docker pull htakeuchi/docker-asciidoctor-jp
 # HTML5版のビルド

--- a/README_jp.md
+++ b/README_jp.md
@@ -1,5 +1,7 @@
 # ロボカップ小型機リーグルール
 
+[English](README.md) | Japanese  
+
 ロボカップ小型機リーグ(SSL)公式ルールの、AsciiDoc形式のソースコードです。  
 旧バージョンのルール(英語)は https://github.com/RoboCup-SSL/ssl-rules-legacy よりご覧いただけます。
 


### PR DESCRIPTION
closes kkimurak/ssl-rules-ja#9  
related kkimurak/ssl-rules-ja#9
日本語版READMEの作成とREADMEに関連したフォーマット(レイアウト不具合修正)を行います。  
またREADMEにおいて、このリポジトリが非公式翻訳であることを明示するようにします。