### PR TITLE
Rules2020/7 キーパーID変更に関するルールの追加

### DIFF
--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -142,12 +142,16 @@ The <<主審/Referee, referee>> tosses a coin with both <<ハンドラ/Robot Han
 <<主審/Referee, 主審>>は両チームの<<ハンドラ/Robot Handler, ハンドラ>>にどのロボットをキーパーとして使用するつもりなのか確認し、<<Game Controller Operator, game controller operator>>に情報を連絡する。 +
 The <<主審/Referee, referee>> asks both <<ハンドラ/Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
 
+キーパーのIDは、<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ中>>もしくはボールの位置がフィールドの相手側ハーフであれば、以下の方法でいつでも変更できる: +
 The keeper id can be changed anytime during the game if the ball is either <<Ball In And Out Of Play, out of play>> or in the opponent's field half by:
 
-. Using the <<Game Controller, game controller>> network interface
-. Asking the <<Game Controller Operator, game controller operator>> to change it in the <<Game Controller, game controller>>. The <<Game Controller Operator, game controller operator>> must not change the keeper id until the ball is at a valid position.
+. <<Game Controller, Game controller>>のネットワークインターフェースを利用する +
+Using the <<Game Controller, game controller>> network interface
+. <<Game Controller Operator, game controller operator>>に、<<Game Controller, game controller>>で設定されているキーパーのIDを変更するよう依頼する。<<Game Controller Operator, Game controller operator>>は、ボールが適切な位置に来るまでキーパーのIDを変更してはならない。 +
+Asking the <<Game Controller Operator, game controller operator>> to change it in the <<Game Controller, game controller>>. The <<Game Controller Operator, game controller operator>> must not change the keeper id until the ball is at a valid position.
 
-NOTE: Teams should only ask for a change once the requirements are met. The <<Game Controller Operator, game controller operator>> is responsible for complying to the rules.
+NOTE: チームは、要件を満たした時にのみ変更を要請する必要がある。<<Game Controller Operator, Game controller operator>>はルールを尊守する必要がある。 +
+Teams should only ask for a change once the requirements are met. The <<Game Controller Operator, game controller operator>> is responsible for complying to the rules.
 
 NOTE: もしチームがキーパーを使用したくない場合、フィールド上に存在しないロボットのIDを選択すること。 +
 If a team does not want to use a keeper, it may select the id of a robot that is not on the field.

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -142,6 +142,13 @@ The <<主審/Referee, referee>> tosses a coin with both <<ハンドラ/Robot Han
 <<主審/Referee, 主審>>は両チームの<<ハンドラ/Robot Handler, ハンドラ>>にどのロボットをキーパーとして使用するつもりなのか確認し、<<Game Controller Operator, game controller operator>>に情報を連絡する。 +
 The <<主審/Referee, referee>> asks both <<ハンドラ/Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
 
+The keeper id can be changed anytime during the game if the ball is either <<Ball In And Out Of Play, out of play>> or in the opponent's field half by:
+
+. Using the <<Game Controller, game controller>> network interface
+. Asking the <<Game Controller Operator, game controller operator>> to change it in the <<Game Controller, game controller>>. The <<Game Controller Operator, game controller operator>> must not change the keeper id until the ball is at a valid position.
+
+NOTE: Teams should only ask for a change once the requirements are met. The <<Game Controller Operator, game controller operator>> is responsible for complying to the rules.
+
 NOTE: もしチームがキーパーを使用したくない場合、フィールド上に存在しないロボットのIDを選択すること。 +
 If a team does not want to use a keeper, it may select the id of a robot that is not on the field.
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -142,7 +142,7 @@ The <<主審/Referee, referee>> tosses a coin with both <<ハンドラ/Robot Han
 <<主審/Referee, 主審>>は両チームの<<ハンドラ/Robot Handler, ハンドラ>>にどのロボットをキーパーとして使用するつもりなのか確認し、<<Game Controller Operator, game controller operator>>に情報を連絡する。 +
 The <<主審/Referee, referee>> asks both <<ハンドラ/Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
 
-キーパーのIDは、<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ中>>もしくはボールの位置がフィールドの相手側ハーフであれば、以下の方法でいつでも変更できる: +
+キーパーのIDは、<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ中>>もしくはボールがフィールドの相手側ハーフにあれば、以下の方法でいつでも変更できる: +
 The keeper id can be changed anytime during the game if the ball is either <<Ball In And Out Of Play, out of play>> or in the opponent's field half by:
 
 . <<Game Controller, Game controller>>のネットワークインターフェースを利用する +

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -117,7 +117,7 @@ NOTE: (訳者注)一般的に「ビジョン」と呼称されることが多い
 A game is controlled by the community-maintained ssl-game-controller (https://github.com/RoboCup-SSL/ssl-game-controller).
 It is operated by the <<Game Controller Operator, game controller operator>>. The software translates decisions of the <<主審/Referee, referee>> and the <<Automatic Referee, automatic referee>> into Ethernet communication signals that are broadcast to the network. It maintains the state of the game, tracks all events and acts as a proxy between all participating parties in the game.
 
-game-controllerは試合を行うチームのためにネットワークインターフェースを持っている。各チームはボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>の時に、自動的にキーパーのIDを切り替える事ができるほか、次の機会に向けてロボット交代の意図を伝えることや、<<アドバンテージルール/Advantage Rule, アドバンテージルール>>の要求に応答することができる。 +
+game-controllerは試合を行うチームのためにネットワークインターフェースを持っている。各チームは自動的に<<ゴールキーパーのIDの選択/Choosing Keeper Id, キーパーのIDを切り替える>>事ができるほか、次の機会に向けてロボット交代の意図を伝えることや、<<アドバンテージルール/Advantage Rule, アドバンテージルール>>の要求に応答することができる。 +
 The game-controller has a network interface for the playing teams. They can automatically <<ゴールキーパーのIDの選択/Choosing Keeper Id, change their keeper id>>, they can signal a robot substitution intent for the next opportunity and they can reply to requests of the <<アドバンテージルール/Advantage Rule, advantage rule>>.
 
 NOTE: (訳者注)日本では一般的に「レフボ」と呼称されることが多い。これは、同様の機能を持った旧世代のソフトウェアである「ssl-refbox」、およびその操作担当である「refbox operator」(2018年の大会をもって廃止)に由来する。

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -118,7 +118,7 @@ A game is controlled by the community-maintained ssl-game-controller (https://gi
 It is operated by the <<Game Controller Operator, game controller operator>>. The software translates decisions of the <<主審/Referee, referee>> and the <<Automatic Referee, automatic referee>> into Ethernet communication signals that are broadcast to the network. It maintains the state of the game, tracks all events and acts as a proxy between all participating parties in the game.
 
 game-controllerは試合を行うチームのためにネットワークインターフェースを持っている。各チームはボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>の時に、自動的にキーパーのIDを切り替える事ができるほか、次の機会に向けてロボット交代の意図を伝えることや、<<アドバンテージルール/Advantage Rule, アドバンテージルール>>の要求に応答することができる。 +
-The game-controller has a network interface for the playing teams. They can automatically change their keeper id when the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>>, they can signal a robot substitution intent for the next opportunity and they can reply to requests of the <<アドバンテージルール/Advantage Rule, advantage rule>>.
+The game-controller has a network interface for the playing teams. They can automatically <<ゴールキーパーのIDの選択/Choosing Keeper Id, change their keeper id>>, they can signal a robot substitution intent for the next opportunity and they can reply to requests of the <<アドバンテージルール/Advantage Rule, advantage rule>>.
 
 NOTE: (訳者注)日本では一般的に「レフボ」と呼称されることが多い。これは、同様の機能を持った旧世代のソフトウェアである「ssl-refbox」、およびその操作担当である「refbox operator」(2018年の大会をもって廃止)に由来する。
 


### PR DESCRIPTION
[本家ルール PR7](https://github.com/robocup-ssl/ssl-rules/pull/7)の翻訳作業です。  

- [x] cherry-pick
- [x] resolve conflict (caused by translated link target name) 
- [x] translation
- [ ] review