### PR TITLE
Rules2020/14 ペナルティーキックの削除

### DIFF
--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -66,7 +66,7 @@ A defense area is defined as a rectangle touching the goal lines centrally in fr
 
 
 ===== ペナルティーマーク/Penalty Mark
-それぞれのディフェンスエリアにあるペナルティマークはゴールポストの中間点からディヴィジョンAなら1.2m、ディヴィジョンBなら1m離れた地点にある。したがってディフェンスエリアの外側の角と一致する位置である。 +
+それぞれのディフェンスエリアにあるペナルティマークは(ハーフウェーラインではなく)<<追加のライン/Additional Lines, ミッドライン>>上の、相手チームのゴールのセンターから8m(Division A)もしくは6m(Division B)にある。 +
 For each field half the penalty mark is on the <<追加のライン/Additional Lines, mid-line>> (not halfway line), 8 meters (division A) or 6 meters (division B) away from the opponent goal center.
 
 ==== ゴール/Goals

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -67,10 +67,7 @@ A defense area is defined as a rectangle touching the goal lines centrally in fr
 
 ===== ペナルティーマーク/Penalty Mark
 それぞれのディフェンスエリアにあるペナルティマークはゴールポストの中間点からディヴィジョンAなら1.2m、ディヴィジョンBなら1m離れた地点にある。したがってディフェンスエリアの外側の角と一致する位置である。 +
-For each field half the penalty mark is 1.2 meters for division A and 1 meter for division B, from the midpoint between the goalposts and equidistant to them, thus coinciding with the outer edge of the defense area.
-
-NOTE: ペナルティーマークはミッドラインとディフェンスエリアの交点と一致するので塗装されている必要はない。 +
-The penalty mark does not need to be painted since it coincides with the intersection of the defense area and the mid-line.
+For each field half the penalty mark is on the <<追加のライン/Additional Lines, mid-line>> (not halfway line), 8 meters (division A) or 6 meters (division B) away from the opponent goal center.
 
 ==== ゴール/Goals
 ゴールはそれぞれのゴールラインの中央に配置し、しっかりと固定されなければいけない。ゴールは高さ0.16mの2枚の垂直なサイドウォールと1枚の垂直なリヤウォールがつながって構成されている。ゴールの内側は、ボールの衝撃を吸収し偏向速度を減じるための材質 - 例えば発泡材など - で覆われる必要がある。ゴールの壁と角と上面は白色で塗装される。 +

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -66,7 +66,7 @@ A defense area is defined as a rectangle touching the goal lines centrally in fr
 
 
 ===== ペナルティーマーク/Penalty Mark
-それぞれのディフェンスエリアにあるペナルティマークは(ハーフウェーラインではなく)<<追加のライン/Additional Lines, ミッドライン>>上の、相手チームのゴールのセンターから8m(Division A)もしくは6m(Division B)にある。 +
+それぞれのディフェンスエリアのペナルティマークは(ハーフウェーラインではなく)<<追加のライン/Additional Lines, ミッドライン>>上の、相手チームのゴールのセンターから8m(Division A)もしくは6m(Division B)の地点にある。 +
 For each field half the penalty mark is on the <<追加のライン/Additional Lines, mid-line>> (not halfway line), 8 meters (division A) or 6 meters (division B) away from the opponent goal center.
 
 ==== ゴール/Goals

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -109,7 +109,7 @@ After the ball has been placed, the game is resumed using one of the following c
 For two-staged referee commands, when normal start is sent, an attacker may <<ボールの操作/Ball Manipulation, manipulate the ball>>. A match cannot be resumed directly via normal start.
 
 .用途/Usage
-Normal startは<<キックオフ/Kick-Off, キックオフ>>、<<ペナルティーキック/Penalty Kick, ペナルティキック>>、<<シュートアウト/Shoot-Out, シュートアウト>>の時に使用する。 +
+ノーマルスタートは<<キックオフ/Kick-Off, キックオフ>>、<<ペナルティーキック/Penalty Kick, ペナルティキック>>の時に使用する。 +
 Normal start is used for <<キックオフ/Kick-Off, kick-offs>> and <<ペナルティーキック/Penalty Kick, penalty kicks>>.
 
 NOTE: (訳者注記)この小節で言いたいのは、試合が停止しているときにいきなりNormal Startコマンドが送信されることはなくて、キックオフやペナルティーキックのコマンドが送信されてからその次にNormal startのコマンドが送信されるという事。
@@ -186,28 +186,45 @@ It can also be used to resume the game when the game had to be stopped and no te
 
 ==== ペナルティーキック/Penalty Kick
 .定義/Definition
+ペナルティーキックの手順は以下の通りである: +
 The procedure of a penalty kick is as follows:
 
-. The ball is placed by the human referee on the <<Penalty Mark, penalty mark>>.
-. When the <<Penalty Kick, penalty>> command is issued
-.. The defending keeper has to move to the goal line and keep touching it
-.. One attacking robot is allowed to approach the ball but not touch the ball
-.. All other robots have to be 1m behind the ball such that they do not interfere the penalty kick procedure at any time.
-. When the <<Normal Start, normal start>> command is issued, the attacker is allowed to <<Ball Manipulation, manipulate the ball>>. The ball has to only move towards the opponent goal, as measured by its x coordinate in the coordinate system of <<Vision, SSL-Vision>>.
-. When the ball is <<Ball In And Out Of Play, in play>>, the defending keeper may move freely again
+. ボールが人間の主審により<<ペナルティーマーク/Penalty Mark, ペナルティーマーク>>に置かれる +
+The ball is placed by the human referee on the <<ペナルティーマーク/Penalty Mark, penalty mark>>.
+. <<ペナルティーキック/Penalty Kick, ペナルティー>>コマンドが発行された時、 +
+When the <<Penalty Kick, penalty>> command is issued
+.. 守備側のキーパーはゴールラインまで移動し、それに触れ続けなければならない +
+The defending keeper has to move to the goal line and keep touching it
+.. 攻撃側のロボット1台はボールに近付くことが許されるが、このときボールに触れてはならない。 +
+One attacking robot is allowed to approach the ball but not touch the ball
+.. その他の全てのロボットはペナルティーキックの手順に干渉しないよう、ボールから1m以上後方にいなければならない。 +
+All other robots have to be 1m behind the ball such that they do not interfere the penalty kick procedure at any time.
+. <<ノーマルスタート/Normal Start, ノーマルスタート>>コマンドが発行された時、攻撃側ロボットは<<ボールの操作/Ball Manipulation, ボールを操作>>することが許可される。ボールは<<Vision, SSL-Vision>>の座標系におけるX座標で計測されるところの相手ゴール側にのみ動かすことができる。 +
+When the <<ノーマルスタート/Normal Start, normal start>> command is issued, the attacker is allowed to <<ボールの操作/Ball Manipulation, manipulate the ball>>. The ball has to only move towards the opponent goal, as measured by its x coordinate in the coordinate system of <<Vision, SSL-Vision>>.
+. <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>になった時、守備側のキーパーは再び自由に移動できる。 +
+When the ball is <<Ball In And Out Of Play, in play>>, the defending keeper may move freely again
 
+以下の場合は得点が認められる: +
 A goal is awarded if:
 
-* the ball touches the inner surface of a goal wall or the ground of the goal of the defending team in less than 10 seconds, starting from when the <<Normal Start, normal start>> command is issued
-* the defending team violates any rule
+* <<ノーマルスタート/Normal Start, ノーマルスタート>>コマンドが発行されてから10秒以内に、ボールがゴールの内側表面もしくはゴールの地面に接触する +
+the ball touches the inner surface of a goal wall or the ground of the goal of the defending team in less than 10 seconds, starting from when the <<Normal Start, normal start>> command is issued
+* 守備側チームがなんらかのルールに違反する +
+the defending team violates any rule
 
+以下の場合は得点が認められない: +
 A goal is not awarded if:
 
-* the ball crosses any <<Field Lines, field lines>> outside the goal
-* the defending keeper touches the ball such that the ball speed vector changes direction by at least 90 degrees in 2D space
-* the attacking team violates any rule
+* ボールがゴール外の<<フィールドライン/Field Lines, フィールドライン>>と交差する +
+the ball crosses any <<Field Lines, field lines>> outside the goal
+* 守備側キーパーがボールに触れ、ボールの速度ベクトルが二次元空間で少なくとも90度方向を変える +
+the defending keeper touches the ball such that the ball speed vector changes direction by at least 90 degrees in 2D space
+* 攻撃側チームが何らかのルールに違反する +
+the attacking team violates any rule
 
-NOTE: The restrictions defined for <<Scoring Goals, scoring goals>>, including the ball height limit of 0.15 meters, do not apply here.
+NOTE: 0.15mのボール高さ制限を含め、<<ゴールの得点方法/Scoring Goals, 得点方法>>に定められた制限はここでは適用されない。
+その他のルール、例えば<<ドリブルの超過/Excessive Dribbling, オーバードリブル>>の制限などどは適用される。 +
+The restrictions defined for <<Scoring Goals, scoring goals>>, including the ball height limit of 0.15 meters, do not apply here.
 Other rules like the <<Excessive Dribbling, excessive dribbling>> limitation for example do.
 
 ボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>になっているとき、キッカーは他のロボットがボールに触れるか、ゲームが停止するまでボールに触れてはいけない(「<<ダブルタッチ/Double Touch, ダブルタッチ>>」を参照)。また、ロボットの位置に関する制限が解除される。 +

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -110,7 +110,7 @@ For two-staged referee commands, when normal start is sent, an attacker may <<�
 
 .用途/Usage
 Normal startは<<キックオフ/Kick-Off, キックオフ>>、<<ペナルティーキック/Penalty Kick, ペナルティキック>>、<<シュートアウト/Shoot-Out, シュートアウト>>の時に使用する。 +
-Normal start is used for <<キックオフ/Kick-Off, kick-offs>>, <<ペナルティーキック/Penalty Kick, penalty kicks>> and <<シュートアウト/Shoot-Out, shoot-out>>.
+Normal start is used for <<キックオフ/Kick-Off, kick-offs>> and <<ペナルティーキック/Penalty Kick, penalty kicks>>.
 
 NOTE: (訳者注記)この小節で言いたいのは、試合が停止しているときにいきなりNormal Startコマンドが送信されることはなくて、キックオフやペナルティーキックのコマンドが送信されてからその次にNormal startのコマンドが送信されるという事。
 
@@ -186,23 +186,35 @@ It can also be used to resume the game when the game had to be stopped and no te
 
 ==== ペナルティーキック/Penalty Kick
 .定義/Definition
-ペナルティーキックを開始するには、停止コマンドを送信しなければならず、ボールは人間の<<主審/Referee, 主審>>によって<<ペナルティーマーク/Penalty Mark, ペナルティマーク>>上に配置されなければならない。 +
-To initiate a penalty kick, the stop command has to be sent and the ball has to be placed on the <<ペナルティーマーク/Penalty Mark, penalty mark>> by the human <<主審/Referee, referee>>.
+The procedure of a penalty kick is as follows:
 
-penaltyコマンドが発行されたとき、1台の攻撃側ロボットはボールに触れない範囲で近づくことが許可される。このロボットはキッカーと呼ばれる。守備をするキーパーはゴールラインに触れていなけばならない。それ以外のすべてのロボットは、ゴールラインと平行でペナルティマークから0.4m後ろにあたる線より後ろに移動する必要がある。これらの制約が満たされたら主審は<<ノーマルスタート/Normal Start, normal start>>コマンドにより続けることができる。 +
-When the penalty command is issued, one attacking robot is allowed to approach but not touch the ball. This robot will be referred to as the kicker. The defending keeper has to touch the goal line. All other robots have to move behind a line parallel to the goal line and 0.4 meters behind the penalty mark. When these constraints are met, the referee may continue with a <<ノーマルスタート/Normal Start, normal start>> command.
+. The ball is placed by the human referee on the <<Penalty Mark, penalty mark>>.
+. When the <<Penalty Kick, penalty>> command is issued
+.. The defending keeper has to move to the goal line and keep touching it
+.. One attacking robot is allowed to approach the ball but not touch the ball
+.. All other robots have to be 1m behind the ball such that they do not interfere the penalty kick procedure at any time.
+. When the <<Normal Start, normal start>> command is issued, the attacker is allowed to <<Ball Manipulation, manipulate the ball>>. The ball has to only move towards the opponent goal, as measured by its x coordinate in the coordinate system of <<Vision, SSL-Vision>>.
+. When the ball is <<Ball In And Out Of Play, in play>>, the defending keeper may move freely again
 
-<<ノーマルスタート/Normal Start, normal start>>コマンドが発行されたとき、キッカーはボールをシュートすることが許可される。ペナルティキックから直接ゴールしても得点となる。 +
-When the <<ノーマルスタート/Normal Start, normal start>> command is issued, the kicker is allowed to shoot the ball. A goal may be scored directly from the penalty kick.
+A goal is awarded if:
+
+* the ball touches the inner surface of a goal wall or the ground of the goal of the defending team in less than 10 seconds, starting from when the <<Normal Start, normal start>> command is issued
+* the defending team violates any rule
+
+A goal is not awarded if:
+
+* the ball crosses any <<Field Lines, field lines>> outside the goal
+* the defending keeper touches the ball such that the ball speed vector changes direction by at least 90 degrees in 2D space
+* the attacking team violates any rule
+
+NOTE: The restrictions defined for <<Scoring Goals, scoring goals>>, including the ball height limit of 0.15 meters, do not apply here.
+Other rules like the <<Excessive Dribbling, excessive dribbling>> limitation for example do.
 
 ボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>になっているとき、キッカーは他のロボットがボールに触れるか、ゲームが停止するまでボールに触れてはいけない(「<<ダブルタッチ/Double Touch, ダブルタッチ>>」を参照)。また、ロボットの位置に関する制限が解除される。 +
 When the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<ダブルタッチ/Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
 
 ペナルティーキックがハーフタイムや試合終了の時に実行される場合、アディショナルタイムが許可される。 +
 Additional time is allowed for a penalty kick to be taken at the end of each half or at the end of periods of overtime.
-
-攻撃側のチームがルールを侵害し、ボールがゴールに入った場合、または守備側のチームがルールを侵害し、ボールがゴールに入っていない場合、ペナルティーキックは再度行われる。 +
-The penalty kick is retaken if the attacking team infringes the rules and the ball enters the goal or the defending team infringes the rules and the ball does not enter the goal.
 
 .用途/Usage
 ペナルティキックは複数の<<イエローカード/Yellow Card, イエローカード>>を受け取ったチームを罰するために使用され、それ以外に<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>や<<マルチプルディフェンス/Multiple Defenders, マルチプルディフェンス>>を行ったときにも使用される。 +

--- a/chapters/scoringgoals.adoc
+++ b/chapters/scoringgoals.adoc
@@ -11,7 +11,7 @@ It is not shot directly from an <<間接フリーキック/Indirect Free Kick, i
 The height of the ball did not exceed 0.15 meters after the last touch of an attacker
 
 NOTE: <<シュートアウト/Shoot-Out, シュートアウト>>中は、これらの追加ルールは適用されない。 +
-During <<シュートアウト/Shoot-Out, shoot-out>>, these additional rules do not apply.
+During <<ペナルティーキック/Penalty Kick, penalty kicks>>, these additional rules do not apply.
 
 ゴールが無効とみなされた場合、試合はボールがゴールの外側のゴールラインを交差したものとして継続する。 +
 If the goal is considered invalid, the game will be continued as if the ball crossed the goal line outside the goal.

--- a/chapters/scoringgoals.adoc
+++ b/chapters/scoringgoals.adoc
@@ -10,7 +10,7 @@ It is not shot directly from an <<間接フリーキック/Indirect Free Kick, i
 * アタッカーが最後にボールに触れてから、ボールの高さが0.15mを超えていない +
 The height of the ball did not exceed 0.15 meters after the last touch of an attacker
 
-NOTE: <<シュートアウト/Shoot-Out, シュートアウト>>中は、これらの追加ルールは適用されない。 +
+NOTE: <<ペナルティーキック/Penalty Kick, ペナルティーキック>>中は、これらの追加ルールは適用されない。 +
 During <<ペナルティーキック/Penalty Kick, penalty kicks>>, these additional rules do not apply.
 
 ゴールが無効とみなされた場合、試合はボールがゴールの外側のゴールラインを交差したものとして継続する。 +

--- a/chapters/shootout.adoc
+++ b/chapters/shootout.adoc
@@ -8,7 +8,7 @@ If both teams have the same score after those 5 attempts, each team takes anothe
 
 各チームには1台の攻撃ロボットと1台のキーパーだけが許可される。
 シュートアウトの間、攻撃ロボットと相手のキーパーだけが<<ボールの操作/Ball Manipulation, ボールの操作>>と移動ができる。
-他のロボットは干渉してはいけない。 +
+他のロボットは干渉してはならない。 +
 Only one attacking robot and one keeper is allowed per team. 
 During a shoot-out attempt, the attacking robot and the opponent keeper are the only ones allowed to move and <<ボールの操作/Ball Manipulation, manipulate the ball>>. 
 Other robots are not allowed to interfere.

--- a/chapters/shootout.adoc
+++ b/chapters/shootout.adoc
@@ -1,16 +1,20 @@
 == シュートアウト/Shoot-Out
 
 .定義/Definition
-両チームが交互にゴールに得点を決めようと各チームそれぞれ5回のシュートを試行する。もし両チームとも5回の試行が終わった時に同点であった場合、2チームの得点が異なるまで前と同じ順番でさらに試行回数を増やす。 +
+両チームが交互にそれぞれ5回の<<ペナルティーキック/Penalty Kick, ペナルティーキック>>を試行する。
+もし両チームとも5回の試行が終わった時に同点であった場合、2チームの得点が異なるまで前と同じ順番でさらに試行回数を増やす。 +
 Both teams alternately attempt to score a goal with a <<ペナルティーキック/Penalty Kick, penalty kick>> until each team has performed 5 attempts.
 If both teams have the same score after those 5 attempts, each team takes another attempt in the same order as before until the score of the two teams is different.
 
-各チームには1台の攻撃ロボットと1台のキーパーだけが許可される。シュートアウトの間、攻撃ロボットと相手のキーパーだけが<<ボールの操作/Ball Manipulation, ボールの操作>>と移動ができる。他のロボットは干渉してはいけない。 +
+各チームには1台の攻撃ロボットと1台のキーパーだけが許可される。
+シュートアウトの間、攻撃ロボットと相手のキーパーだけが<<ボールの操作/Ball Manipulation, ボールの操作>>と移動ができる。
+他のロボットは干渉してはいけない。 +
 Only one attacking robot and one keeper is allowed per team. 
 During a shoot-out attempt, the attacking robot and the opponent keeper are the only ones allowed to move and <<ボールの操作/Ball Manipulation, manipulate the ball>>. 
 Other robots are not allowed to interfere.
 
-ロボットはシュートアウトの間に<<ロボットの交代/Robot Substitution, 交代>>してもよい。新しいロボットを即時入れても良い。 +
+ロボットはシュートアウトの間に<<ロボットの交代/Robot Substitution, 交代>>してもよい。
+新しいロボットを即時入れても良い。 +
 Robots may be <<ロボットの交代/Robot Substitution, substituted>> between shoot-out attempts. 
 The new robot may be put in right away.
 

--- a/chapters/shootout.adoc
+++ b/chapters/shootout.adoc
@@ -1,46 +1,18 @@
 == シュートアウト/Shoot-Out
+
 .定義/Definition
 両チームが交互にゴールに得点を決めようと各チームそれぞれ5回のシュートを試行する。もし両チームとも5回の試行が終わった時に同点であった場合、2チームの得点が異なるまで前と同じ順番でさらに試行回数を増やす。 +
-Both teams alternately attempt to score a goal until each team has performed 5 attempts. If both teams have the same score after those 5 attempts, each team takes another attempt in the same order as before until the score of the two teams is different.
+Both teams alternately attempt to score a goal with a <<ペナルティーキック/Penalty Kick, penalty kick>> until each team has performed 5 attempts.
+If both teams have the same score after those 5 attempts, each team takes another attempt in the same order as before until the score of the two teams is different.
 
 各チームには1台の攻撃ロボットと1台のキーパーだけが許可される。シュートアウトの間、攻撃ロボットと相手のキーパーだけが<<ボールの操作/Ball Manipulation, ボールの操作>>と移動ができる。他のロボットは干渉してはいけない。 +
-Only one attacking robot and one keeper is allowed per team. During a shoot-out attempt, the attacking robot and the opponent keeper are the only ones allowed to move and <<ボールの操作/Ball Manipulation, manipulate the ball>>. Other robots are not allowed to interfere.
-
-シュートアウトの手順は以下である: +
-The procedure of a shoot-out attempt is as follows:
-
-. ボールは相手のゴールから(ディヴィジョンAなら)8mか(ディヴィジョンBなら)6mの位置にある<<追加のライン/Additional Lines, ミッドライン>>(ハーフウェイラインではない)に人間の審判によって置かれる。 +
-The ball is placed by the human referee on the <<追加のライン/Additional Lines, mid-line>> (not halfway line), 8 meters (division A) or 6 meters (division B) away from the opponent goal.
-. <<ペナルティーキック/Penalty Kick, ペナルティーキック>>のコマンドが発行されたとき、守備側チームのキーパーはゴールラインに移動し、ラインに触れ続けなければならない +
-When the <<ペナルティーキック/Penalty Kick, penalty>> command is issued, the defending keeper has to move to the goal line and keep touching it.
-. <<ノーマルスタート/Normal Start, ノーマルスタート>>のコマンドが発行されたとき、アタッカーは<<ボールの操作/Ball Manipulation, ボールを操作する>>ことが許可される。ボールは相手ゴールに向かって動かさなければならない。これは、SSL-Visionの座標系におけるx座標によって測定されている。 +
-When the <<ノーマルスタート/Normal Start, normal start>> command is issued, the attacker is allowed to <<ボールの操作/Ball Manipulation, manipulate the ball>>. The ball has to only move towards the opponent goal, as measured by its x coordinate in the coordinate system of <<Vision, SSL-Vision>>.
-. ボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>になった時、守備側チームのキーパは<<ペナルティーキック/Penalty Kick,  ペナルティキック>>と同じように再び自由に動いてよい。 +
-When the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the defending keeper may move freely again, analogous to a <<ペナルティーキック/Penalty Kick, penalty kick>>.
-
-以下の場合に得点が与えられる: +
-A goal is awarded if:
-
-* <<ノーマルスタート/Normal Start, ノーマルスタート>>のコマンドが発行されてから10秒以内に守備側チームのゴールの地面もしくはゴールウォールの内面にボールが接触した。 +
-the ball touches the inner surface of a goal wall or the ground of the goal of the defending team in less than 10 seconds, starting from when the <<ノーマルスタート/Normal Start, normal start>> command is issued
-* 守備側チームがいかなる違反も犯していない +
-the defending team violates any rule
-
-以下の場合に得点が与えられない: +
-A goal is not awarded if:
-
-* ボールがゴールより外側のいずれかの<<フィールドライン/Field Lines, フィールドライン>>を横切った +
-the ball crosses any <<フィールドライン/Field Lines, field lines>> outside the goal
-* 守備側チームのキーパーが2次元空間内で少なくとも90°以上ボールの速度ベクトルを変えるようにボールに触れる +
-the defending keeper touches the ball such that the ball speed vector changes direction by at least 90 degrees in 2D space
-* 攻撃側チームが何らかの違反を犯した +
-the attacking team violates any rule
-
-NOTE: <<ゴールの得点方法/Scoring Goals, ゴールの得点>>のために定義された制限はここでは適用されない。これには0.15mのボールの高さ制限も含まれる。例えば<<ドリブルの超過/Excessive Dribbling, ドリブルの超過>>なども該当する。 +
-The restrictions defined for <<ゴールの得点方法/Scoring Goals, scoring goals>> do not apply here. This explicitly includes the ball height limit of 0.15 meters. Other rules like the <<ドリブルの超過/Excessive Dribbling, excessive dribbling>> limitation for example do.
+Only one attacking robot and one keeper is allowed per team. 
+During a shoot-out attempt, the attacking robot and the opponent keeper are the only ones allowed to move and <<ボールの操作/Ball Manipulation, manipulate the ball>>. 
+Other robots are not allowed to interfere.
 
 ロボットはシュートアウトの間に<<ロボットの交代/Robot Substitution, 交代>>してもよい。新しいロボットを即時入れても良い。 +
-Robots may be <<ロボットの交代/Robot Substitution, substituted>> between shoot-out attempts. The new robot may be put in right away.
+Robots may be <<ロボットの交代/Robot Substitution, substituted>> between shoot-out attempts. 
+The new robot may be put in right away.
 
 NOTE: シュートアウト中は<<タイムアウト/Timeouts, タイムアウト>>は許可されていない事に注意する事。 +
 Note that <<タイムアウト/Timeouts, timeouts>> are not allowed during shoot-out.
@@ -48,4 +20,3 @@ Note that <<タイムアウト/Timeouts, timeouts>> are not allowed during shoot
 .用途/Usage
 シュートアウトは直前の<<ゲームステージ/Game Stages, ゲームステージ>>で両チームが同じ点の場合に、勝ち抜き戦の勝者を決定するために使用される。 +
 Shoot-Out is used to determine the winner of an elimination match if both teams scored the same amount of goals in previous <<ゲームステージ/Game Stages, game stages>>.
-


### PR DESCRIPTION
[本家ルール PR14](https://github.com/robocup-ssl/ssl-rules/pull/14)の翻訳作業です。  
「削除」としていますが、実態は現在シュートアウトで用いられているような1-on-1への置き換えです。もう少し良い表現があればと思いますが....  

- [x] cherry-pick
- [x] resolve conflict (caused by translated link target name) 
- [x] translation
- [ ] review