### PR TITLE
Rules2020/27 チャレンジフラッグ

### DIFF
--- a/chapters/challengeflag.adoc
+++ b/chapters/challengeflag.adoc
@@ -1,0 +1,16 @@
+== Challenge Flag
+
+A challenge flag allows teams to challenge a decision of the referee:
+
+. If referees decision was correct, team loses a timeout.
+. If referees decision was incorrect, the correct decision is applied and the team doesn't lose a timeout.
+
+NOTE: The flag is consumed in both cases.
+
+Only one ruling may be challenged at a time.
+
+The team must have at least one timeout left before using a challenge flag.
+
+Each team will receive *three flags* at the start of the game.
+
+NOTE: This rule is inspired by challenge flags in American football.

--- a/chapters/challengeflag.adoc
+++ b/chapters/challengeflag.adoc
@@ -1,16 +1,24 @@
-== Challenge Flag
+== チャレンジフラッグ/Challenge Flag
 
+チャレンジフラッグは各チームに、主審の決定に対するチャレンジを許可する: +
 A challenge flag allows teams to challenge a decision of the referee:
 
-. If referees decision was correct, team loses a timeout.
-. If referees decision was incorrect, the correct decision is applied and the team doesn't lose a timeout.
+. 主審の決定が正しかった場合、チームはタイムアウトを取得したことになる +
+If referees decision was correct, team loses a timeout.
+. 主審の決定が誤りであった場合、正しい決定が適用されチームはタイムアウトを消費しない。 +
+If referees decision was incorrect, the correct decision is applied and the team doesn't lose a timeout.
 
-NOTE: The flag is consumed in both cases.
+NOTE: いずれの場合もフラッグは消費される。 +
+The flag is consumed in both cases.
 
+一度のチャレンジにつき、一つのルールに関してチャレンジが行われる。 +
 Only one ruling may be challenged at a time.
 
+チャレンジフラッグを使用するチームは、少なくとも一回のタイムアウト権を有していなければならない。 +
 The team must have at least one timeout left before using a challenge flag.
 
+各チームは、試合開始時に *3本* のフラッグを受け取る。 +
 Each team will receive *three flags* at the start of the game.
 
-NOTE: This rule is inspired by challenge flags in American football.
+NOTE: このルールは、アメリカンフットボールのチャレンジフラッグに着想を得ている。 +
+This rule is inspired by challenge flags in American football.

--- a/sslrules.adoc
+++ b/sslrules.adoc
@@ -42,6 +42,8 @@ include::chapters/shootout.adoc[]
 
 include::chapters/emergencystop.adoc[]
 
+include::chapters/challengeflag.adoc[]
+
 include::chapters/rulechanges.adoc[]
 
 include::chapters/appendix.adoc[]


### PR DESCRIPTION
[本家ルール PR27](https://github.com/robocup-ssl/ssl-rules/pull/27)の翻訳作業です。  

- [x] cherry-pick
- [x] ~~resolve conflict (caused by translated link target name)~~ new rule, no conflict 
- [x] translation
- [ ] review