### PR TITLE
機能していないリンクの修正

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -19,8 +19,8 @@ Note that the information shown in this table here is incomplete. Please read th
 
 | 準備完了 +
 Prepared
-| <<キックオフ/Kick-Off, キックオフ>>、<<ペナルティキック/Penalty Kick, ペナルティキック>>中 +
-during  <<キックオフ/Kick-Off, Kick-Off>>, <<ペナルティキック/Penalty Kick, Penalty Kick>>
+| <<キックオフ/Kick-Off, キックオフ>>、<<ペナルティーキック/Penalty Kick, ペナルティーキック>>中 +
+during  <<キックオフ/Kick-Off, Kick-Off>>, <<ペナルティーキック/Penalty Kick, Penalty Kick>>
 | <<ノーマルスタート/Normal Start,ノーマルスタート>> +
 <<ノーマルスタート/Normal Start, Normal Start>>
 | auto referee
@@ -95,8 +95,8 @@ always
 <<停止/Stop, Stop>> -> <<フリーキック/Free Kick, Free Kick>>
 | auto referee
 
-| <<エイムレスキック/aimless-kick, エイムレスキック>> +
-<<エイムレスキック/aimless-kick, Aimless Kick>>
+| <<aimless-kick, エイムレスキック>> +
+<<aimless-kick, Aimless Kick>>
 | <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>> +
 <<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>>
 | <<停止/Stop, ストップ>> -> <<フリーキック/Free Kick, フリーキック>> +
@@ -243,8 +243,8 @@ referee -> game controller
 <<停止/Stop, Stop>> -> <<フリーキック/Free Kick, Free Kick>>
 | auto referee
 
-| <<オーバードリブル/Excessive Dribbling, オーバードリブル>> +
-<<オーバードリブル/Excessive Dribbling, Excessive Dribbling>>
+| <<ドリブルの超過/Excessive Dribbling, オーバードリブル>> +
+<<ドリブルの超過/Excessive Dribbling, Excessive Dribbling>>
 | <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>> +
 <<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>>
 | <<停止/Stop, ストップ>> -> <<フリーキック/Free Kick, フリーキック>> +
@@ -333,7 +333,7 @@ placement timer increased by 10 seconds
 | 状況/Situation | ディヴィジョンAの時間/Div A Time | ディヴィジョンBの時間/Div B Time
 
 | <<イエローカード/Yellow Card, イエローカード>>によるロボット除去 +
-Remove robot for <<Yellow Card>>
+Remove robot for <<イエローカード/Yellow Card, Yellow Card>>
 | 10 s       | 10 s
 
 | <<ペナルティーキック/Penalty Kick, ペナルティーキック>> +
@@ -370,7 +370,7 @@ Division A plays on a <<フィールドの大きさ/Dimensions, larger field>> w
 Division A plays with <<ロボットの台数/Number Of Robots, more robots>> than division B.
 * <<ボール配置/Ball Placement, ボール配置>>の手順はディヴィジョンAでは必須であり、ディヴィジョンBでは任意である。 +
 The automatic <<ボール配置/Ball Placement, ball placement>> procedure is mandatory for division A and optional for division B.
-* <<エイムレスキック/aimless-kick, エイムレスキック>>のルールはディヴィジョンBにのみ適用される。 +
-The <<エイムレスキック/aimless-kick, aimless kick>> rule only applies to division B.
+* <<aimless-kick, エイムレスキック>>のルールはディヴィジョンBにのみ適用される。 +
+The <<aimless-kick, aimless kick>> rule only applies to division B.
 * ディヴィジョンAはいくつかの状況における時間切れまでの時間が短い。 +
 Division A has shorter timeouts in some situations

--- a/chapters/ballleavesthefield.adoc
+++ b/chapters/ballleavesthefield.adoc
@@ -56,7 +56,7 @@ A corner kick is used to restart the game after the ball left the field by cross
 The ball has to be placed at the position from where the ball was kicked (see the <<フリーキック/Free Kick, free kick>> rules for the exact ball position rules).
 
 ボールが配置された後、ボールがフィールドから出る前に最後に触れたチームの相手チームに<<フリーキック/Free Kick, フリーキック>>が与えられる。 +
-After the ball has been placed, a <<Free Kick, free kick>> is awarded to the opponent of the team that last touched the ball before it left the field.
+After the ball has been placed, a <<フリーキック/Free Kick, free kick>> is awarded to the opponent of the team that last touched the ball before it left the field.
 
 .用途/Usage
 ボールがロボットに触れたあと、ボールが他のロボットに触れることなく、ミッドラインに交差して相手チームのゴールラインからフィールド外にボールが出たとき、それはエイムレスキックである。 +

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -145,7 +145,7 @@ The <<主審/Referee, referee>> tosses a coin with both <<ハンドラ/Robot Han
 The <<主審/Referee, referee>> asks both <<ハンドラ/Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
 
 キーパーのIDは、<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ中>>もしくはボールがフィールドの相手側ハーフにあれば、以下の方法でいつでも変更できる: +
-The keeper id can be changed anytime during the game if the ball is either <<Ball In And Out Of Play, out of play>> or in the opponent's field half by:
+The keeper id can be changed anytime during the game if the ball is either <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>> or in the opponent's field half by:
 
 . <<Game Controller, Game controller>>のネットワークインターフェースを利用する +
 Using the <<Game Controller, game controller>> network interface

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -1,9 +1,9 @@
 == 反則/Offenses
 === 試合の停滞/No Progress In Game
-両チームが<<ボールの操作/Ball Manipulation, ボールを操作する>>ことが許されているにもかかわらず5秒 (ディヴィジョンA)もしくは10秒 (ディヴィジョンB)に亘って試合に進展がなかった場合、試合は<<停止/Stop, 停止され>>、<<フォーススタート/Forced Start, フォーススタート>>で再開される。 +
+両チームが<<ボールの操作/Ball Manipulation, ボールを操作する>>ことが許されているにもかかわらず5秒 (ディヴィジョンA)もしくは10秒 (ディヴィジョンB)に亘って試合に進展がなかった場合、試合は<<停止/Stop, 停止され>>、<<フォーススタート/Force Start, フォーススタート>>で再開される。 +
 If there is no progress in the game for 5 seconds (Division A) or 10 seconds (Division B) while both teams are allowed to
 <<ボールの操作/Ball Manipulation, manipulate the ball>>, the game is <<停止/Stop, stopped>>
-and continued by a <<フォーススタート/Forced Start, forced start>>.
+and continued by a <<フォーススタート/Force Start, forced start>>.
 
 === ダブルタッチ/Double Touch
 
@@ -66,15 +66,15 @@ Violations in this section and its subsections increase the foul counter if not 
 NOTE: 人間の主審は、各セクションに記述された罰則に関係なく、そのファウルが繰り返される場合は<<イエローカード/Yellow Card, イエローカード>>を、特に極端な場合は<<レッドカード/Red Card, レッドカード>>を即座に与えることを選択できる。 +
 Regardless, of the prescribed penalties in this section, if a
 foul is severe or repeated, the referee can choose to immediately
-issue a <<Yellow Card, yellow card>> or in extreme cases a <<Red Card,
+issue a <<イエローカード/Yellow Card, yellow card>> or in extreme cases a <<レッドカード/Red Card,
 red card>>.
 
 
 
 ==== 試合の停止を伴うファウル/Stopping Fouls
 このセクションにあるファウルは試合を<<停止/Stop, 停止>>させ、反則が発生した時点でボールが置かれていた位置からの<<フリーキック/Free Kick, フリーキック>>で再開する。 +
-Fouls in this section cause the game to <<Stop, stop>> and then resume
-with a <<Free Kick, free kick>> from the position where the ball was
+Fouls in this section cause the game to <<停止/Stop, stop>> and then resume
+with a <<フリーキック/Free Kick, free kick>> from the position where the ball was
 located when the foul began happening.
 
 ===== ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area
@@ -130,7 +130,7 @@ A robot must not kick the ball over the field boundary such that the ball leaves
 ===== キーパーによるボール保持/Keeper Held Ball
 ボールはディヴィジョンAであれば5秒、ディヴィジョンBであれば10秒を超えて
 <<ディフェンスエリア/Defense Area, デイフェンスエリア>>に留まってはならない。 +
-The ball must not be kept in the <<Defense Area, defense area>> for more than
+The ball must not be kept in the <<ディフェンスエリア/Defense Area, defense area>> for more than
 5 seconds (Division A) or 10 seconds (Division B).
 
 ===== ドリブルの超過/Excessive Dribbling
@@ -147,7 +147,7 @@ NOTE: (訳者注)一般的に「オーバードリブル」と呼称されるこ
 ==== 試合の停止を伴わないファウル/Non Stopping Fouls
 このセクションにあるファウルは<<停止/Stop, 試合を停止しない>>。
 代わりに、試合は通常どおり続行される。 +
-Fouls in this section do not cause a <<Stop, stop>>.
+Fouls in this section do not cause a <<停止/Stop, stop>>.
 Instead, the game continues normally.
 
 同一の「試合の停止を伴わないファウル」は、その違反状態が解消されるか、最初に違反が認定されてから2秒が経過するまでは処理されない。
@@ -174,7 +174,7 @@ At the moment of collision of two robots of different teams, the difference of t
 
 ==== アウトオブプレイ中のファウル/Fouls While Ball Out Of Play
 このセクションにあるファウルはボールが<<インプレイとアウトオブプレイ/Ball In And Out Of Play, アウトオブプレイ>>の時にのみ発生する。 +
-Fouls in this section can only occur when the ball is <<Ball In And Out Of Play, out of play>>.
+Fouls in this section can only occur when the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, out of play>>.
 
 各ファウルには、再度ファウルとなるまでチームごとに2秒の猶予時間がある。 +
 Each foul has a grace period of 2 seconds per team until it is raised again.
@@ -192,7 +192,7 @@ A robot's distance to the ball must be at least 0.5 meters during an opponent <<
 While the foul is being committed, the timer of the opponent team for bringing the ball into play is reset.
 
 <<主審/Referee, 人間の主審>>は、著しい妨害を受けた<<キックオフ/Kick-Off, キックオフ>>もしくは<<フリーキック/Free Kick, フリーキック>>をやり直す事ができる。 +
-The <<Referee, human referee>> may decide to repeat the <<Kick-Off, kick-off>> or <<Free Kick, free kick>> on significant disturbances.
+The <<Referee, human referee>> may decide to repeat the <<Kick-Off, kick-off>> or <<フリーキック/Free Kick, free kick>> on significant disturbances.
 
 NOTE: <<停止/Stop, stop>>中は、ボールに近すぎる事に対する自動的な罰則はない。主審はチームが必要な距離を守っていない場合、<<イエローカード/Yellow Card, イエローカード>>を発行することで非スポーツマン行為を罰することができる。詳しい説明は「<<停止/Stop, 停止>>」を参照する事。 +
 During <<停止/Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<非スポーツマン行為/Unsporting Behavior,unsporting behavior>> by issuing a <<イエローカード/Yellow Card, yellow card>> if it does not respect the required distance. See <<停止/Stop, stop>> for further explanation.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -192,7 +192,7 @@ A robot's distance to the ball must be at least 0.5 meters during an opponent <<
 While the foul is being committed, the timer of the opponent team for bringing the ball into play is reset.
 
 <<主審/Referee, 人間の主審>>は、著しい妨害を受けた<<キックオフ/Kick-Off, キックオフ>>もしくは<<フリーキック/Free Kick, フリーキック>>をやり直す事ができる。 +
-The <<Referee, human referee>> may decide to repeat the <<Kick-Off, kick-off>> or <<フリーキック/Free Kick, free kick>> on significant disturbances.
+The <<主審/Referee, human referee>> may decide to repeat the <<キックオフ/Kick-Off, kick-off>> or <<フリーキック/Free Kick, free kick>> on significant disturbances.
 
 NOTE: <<停止/Stop, stop>>中は、ボールに近すぎる事に対する自動的な罰則はない。主審はチームが必要な距離を守っていない場合、<<イエローカード/Yellow Card, イエローカード>>を発行することで非スポーツマン行為を罰することができる。詳しい説明は「<<停止/Stop, 停止>>」を参照する事。 +
 During <<停止/Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<非スポーツマン行為/Unsporting Behavior,unsporting behavior>> by issuing a <<イエローカード/Yellow Card, yellow card>> if it does not respect the required distance. See <<停止/Stop, stop>> for further explanation.

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -130,7 +130,7 @@ New automatic referee implementations can be provided, given that the source cod
 <<ゲームイベント表/Game Event Table, ゲームイベント表>>はAutomatic Refereeの実装がどのゲームイベントを検出できなけらばならないかを示す。
 <<技術委員会/Technical Committee, 技術委員会>>および両チームが同意すれば、個別のゲームイベントをオートレフェリーでの処理上で、もしくは完全に無効化することができる。 +
 The <<ゲームイベント表/Game Event Table, Game Event Table>> shows which game events an automatic referee implementation must be able to detect.
-Individual game events can be disabled completely or in some automatic referee implementations if both teams and the <<Technical Committee, technical committee>> agree.
+Individual game events can be disabled completely or in some automatic referee implementations if both teams and the <<技術委員会/Technical Committee, technical committee>> agree.
 
 存在する実装はGithubで確認することができる。: https://github.com/RoboCup-SSL/ssl-autorefs +
 Existing implementations can be found on Github: https://github.com/RoboCup-SSL/ssl-autorefs.

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -146,7 +146,7 @@ These flags are responsible for communicating various intents, such as: <<タイ
 
 <<主審/Referee, 主審>>もしくは<<Game Controller Operator, game controller operator>>がコミュニケーションフラッグを確認する必要がある。
 ジェスチャーや野次は<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>とみなされ、一度の警告ののちに<<レッドカード/Red Card, レッドカード>>となる。
-The <<Referee, referee>> or <<Game Controller Operator, game controller operator>> has to acknowledge the communication flag.
+The <<主審/Referee, referee>> or <<Game Controller Operator, game controller operator>> has to acknowledge the communication flag.
 Any gesturing and yelling will be considered <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>, punished by a <<レッドカード/Red Card, red card>> after the first warning.
 
 コミュニケーションフラッグは大会主催者より提供される。

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -141,8 +141,8 @@ NOTE: (訳者注記)この小節で言いたいのは、試合が停止してい
 ボールはフィールドの中心に人によって配置されなければならない。 +
 The ball has to be placed in the center of the field by the human referee.
 
-kick-offコマンドが発行されたとき、すべてのロボットはセンターサークルを除く自分たちの陣地側のフィールド半面に移動しなければならない。ただし、攻撃側チームのアタッカーロボット1台はセンターサークル内に侵入することが許可される。このロボットはキッカーと呼ばれる。すべてのロボットはボールに触れてはいけない。 +
-When the kick-off command is issued, all robots have to move to their own half of the field excluding the <<Center Circle, center circle>>. However, one robot of the attacking team is also allowed to be inside the whole center circle. This robot will be referred to as the kicker. No robot is allowed to touch the ball.
+kick-offコマンドが発行されたとき、すべてのロボットは<<センターサークル/Center Circle, センターサークル>>を除く自分たちの陣地側のフィールド半面に移動しなければならない。ただし、攻撃側チームのアタッカーロボット1台はセンターサークル内に侵入することが許可される。このロボットはキッカーと呼ばれる。すべてのロボットはボールに触れてはいけない。 +
+When the kick-off command is issued, all robots have to move to their own half of the field excluding the <<センターサークル/Center Circle, center circle>>. However, one robot of the attacking team is also allowed to be inside the whole center circle. This robot will be referred to as the kicker. No robot is allowed to touch the ball.
 
 <<ノーマルスタート/Normal Start, normal start>>コマンドが送信されたとき、キッカーはボールをシュートすることが許可される。キックオフからゴールを直接獲得することができる。 +
 When the <<ノーマルスタート/Normal Start, normal start>> command is issued, the kicker is allowed to shoot the ball. A goal may be scored directly from the kick-off.
@@ -194,7 +194,7 @@ The procedure of a penalty kick is as follows:
 . ボールが人間の主審により<<ペナルティーマーク/Penalty Mark, ペナルティーマーク>>に置かれる +
 The ball is placed by the human referee on the <<ペナルティーマーク/Penalty Mark, penalty mark>>.
 . <<ペナルティーキック/Penalty Kick, ペナルティー>>コマンドが発行された時、 +
-When the <<Penalty Kick, penalty>> command is issued
+When the <<ペナルティーキック/Penalty Kick, penalty>> command is issued
 .. 守備側のキーパーはゴールラインまで移動し、それに触れ続けなければならない +
 The defending keeper has to move to the goal line and keep touching it
 .. 攻撃側のロボット1台はボールに近付くことが許されるが、このときボールに触れてはならない。 +
@@ -204,15 +204,15 @@ All other robots have to be 1m behind the ball such that they do not interfere t
 . <<ノーマルスタート/Normal Start, ノーマルスタート>>コマンドが発行された時、攻撃側ロボットは<<ボールの操作/Ball Manipulation, ボールを操作>>することが許可される。ボールは<<Vision, SSL-Vision>>の座標系におけるX座標で計測されるところの相手ゴール側にのみ動かすことができる。 +
 When the <<ノーマルスタート/Normal Start, normal start>> command is issued, the attacker is allowed to <<ボールの操作/Ball Manipulation, manipulate the ball>>. The ball has to only move towards the opponent goal, as measured by its x coordinate in the coordinate system of <<Vision, SSL-Vision>>.
 . <<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>になった時、守備側のキーパーは再び自由に移動できる。 +
-When the ball is <<Ball In And Out Of Play, in play>>, the defending keeper may move freely again
+When the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the defending keeper may move freely again
 . 10秒経過した後にボールが引き続き<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>であった場合、試合は停止され<<ゴールキック/Goal Kick, ゴールキック>>で再開される。 +
-If the ball is still <<Ball In And Out Of Play, in play>> after 10 seconds, the game is stopped and then continued by a <<Goal Kick, goal kick>> for the defending team.
+If the ball is still <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>> after 10 seconds, the game is stopped and then continued by a <<ゴールキック/Goal Kick, goal kick>> for the defending team.
 
 以下の場合は得点が認められる: +
 A goal is awarded if:
 
 * <<ノーマルスタート/Normal Start, ノーマルスタート>>コマンドが発行されてから、ボールがゴールの内側表面もしくはゴールの地面に接触する +
-the ball touches the inner surface of a goal wall or the ground of the goal of the defending team, starting from when the <<Normal Start, normal start>> command is issued
+the ball touches the inner surface of a goal wall or the ground of the goal of the defending team, starting from when the <<ノーマルスタート/Normal Start, normal start>> command is issued
 * 守備側チームがなんらかのルールに違反する +
 the defending team violates any rule
 
@@ -220,7 +220,7 @@ the defending team violates any rule
 A goal is not awarded if:
 
 * ボールがゴール外の<<フィールドライン/Field Lines, フィールドライン>>と交差する +
-the ball crosses any <<Field Lines, field lines>> outside the goal
+the ball crosses any <<フィールドライン/Field Lines, field lines>> outside the goal
 * 守備側キーパーがボールに触れ、ボールの速度ベクトルが二次元空間で少なくとも90度方向を変える +
 the defending keeper touches the ball such that the ball speed vector changes direction by at least 90 degrees in 2D space
 * 攻撃側チームが何らかのルールに違反する +
@@ -228,8 +228,8 @@ the attacking team violates any rule
 
 NOTE: 0.15mのボール高さ制限を含め、<<ゴールの得点方法/Scoring Goals, 得点方法>>に定められた制限はここでは適用されない。
 その他のルール、例えば<<ドリブルの超過/Excessive Dribbling, オーバードリブル>>の制限などどは適用される。 +
-The restrictions defined for <<Scoring Goals, scoring goals>>, including the ball height limit of 0.15 meters, do not apply here.
-Other rules like the <<Excessive Dribbling, excessive dribbling>> limitation for example do.
+The restrictions defined for <<ゴールの得点方法/Scoring Goals, scoring goals>>, including the ball height limit of 0.15 meters, do not apply here.
+Other rules like the <<ドリブルの超過/Excessive Dribbling, excessive dribbling>> limitation for example do.
 
 ペナルティーキックがハーフタイムや試合終了の時に実行される場合、アディショナルタイムが許可される。 +
 Additional time is allowed for a penalty kick to be taken at the end of each half or at the end of periods of overtime.
@@ -254,7 +254,7 @@ the ball moved at least 0.05 meters following a <<キックオフ/Kick-Off, kick
 * <<キックオフ/Kick-Off, キックオフ>>開始から10秒が経過した時 +
 10 seconds passed following a <<キックオフ/Kick-Off, kick-off>>.
 * <<フリーキック/Free Kick, フリーキック>>から、ディヴィジョンAでは5秒、ディヴィジョンBでは10秒が経過した時 +
-5 seconds (Division A) or 10 seconds (Division B) passed following a <<Free Kick, free kick>>.
+5 seconds (Division A) or 10 seconds (Division B) passed following a <<フリーキック/Free Kick, free kick>>.
 
 NOTE: 0.05メートルの距離の理論的根拠については「<<ダブルタッチ/Double Touch, ダブルタッチ>>」を参照すること +
 see <<ダブルタッチ/Double Touch, double touch>> for the rationale of the 0.05 meter distance
@@ -272,7 +272,7 @@ If the yellow card is shown as a result of <<非スポーツマン行為/Unsport
 Upon receipt of a yellow card, the number of robots allowed on the field for the penalized team decreases by one. If, after this decrease, the team has more robots than permitted on the field, a robot must be <<ロボットの交代/Robot Substitution, taken out>>.
 
 イエローカードは自動的には試合を停止させない。<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>であれば、イエローカードを受けたチームは10秒間で、<<ロボットの交代/Robot Substitution, 自動的にロボットを退場>>させることができる。もしその時間でロボットが退場しなかった場合、ゲームは<<ロボットの交代/Robot Substitution, 手動でのロボット退場>>のため停止させられる。 +
-A yellow card does not lead to a stop automatically. If the the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the team will have 10 seconds to <<Robot Substitution, automatically remove the robot>>. If a robot is not taken out within time, the game is stopped for <<ロボットの交代/Robot Substitution, manual substitution>>.
+A yellow card does not lead to a stop automatically. If the the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the team will have 10 seconds to <<ロボットの交代/Robot Substitution, automatically remove the robot>>. If a robot is not taken out within time, the game is stopped for <<ロボットの交代/Robot Substitution, manual substitution>>.
 
 NOTE: このルールは、イエローカードを受け取った後、ゲームが自動的に停止しない可能性があることを意味する。しかしながら、例えば部品を落とすといった、イエローカードの対象となるファウルがあった場合はゲームは停止する。したがって、これらのファウルのいずれかが発生した場合、チームはロボットを手動で取り除くことができる。 +
 This rule implies that after receiving a yellow card, the game might not be automatically stopped. However, the game will be stopped if the foul that led to the yellow card causes a game stoppage, e.g. dropping parts. Therefore, if one of those fouls occurred, the team is allowed to manually remove the robot.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -20,7 +20,7 @@ The ball must be at least 2 meters away from the halfway line.
 Additionally, robots can be taken out from any position during <<試合の停止/Stopping The Game, game stoppage>> by the <<ハンドラ/Robot Handler, robot handler>> using the procedure below:
 
 . <<ハンドラ/Robot Handler, ハンドラ>>はロボットを外に出す +
-The <<Robot Handler, robot handler>> takes robots out.
+The <<ハンドラ/Robot Handler, robot handler>> takes robots out.
 . <<ハンドラ/Robot Handler, ハンドラ>>は交代が完了したら<<主審/Referee, 主審>>に連絡する +
 The <<ハンドラ/Robot Handler, robot handler>> informs the <<主審/Referee, referee>> when done.
 . 両チームともロボットの交代が終わったら、<<主審/Referee, 主審>>は<<Game Controller Operator, game controller operator>>に連絡する。 +


### PR DESCRIPTION
Closes kkimurak/ssl-rules-ja#27 
加えて、自動的にこのミスを検出できる機構の実装を目指します。

現状のアイデア
1. リンク要素を抽出
2. リンク (a href="#_日本語_english")からhref=""内を抜き出す
3. sort | uniqでuniqueなリストにする
4. _で始まらないリンクを無視する
   asciidocのリンクはhtmlにすると#_から始まる特徴を有する
   これで無関係なリンクを無視できる

微妙なところ(抽出)までできるスクリプト
```sh
# BUG : 最長マッチするため、同一行に複数リンクが存在すると最初の<aから最後の/a>まで全てが残る
# 対処アイデア : <aの前に改行を仕込む
$ grep "<a href=\"#" sslrules.html | sed 's:.*href="\#\(.*\)">.*:\1:g' | sort | uniq | grep " "
```