### PR TITLE
Rules2021/41 表現の改善

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -160,7 +160,7 @@ the violation before being penalized additional times.
 
 ===== 相手ディフェンスエリア内でのアタッカーのボールへの接触/Attacker Touched Ball In Opponent Defense Area
 ボールが部分的にもしくは完全に相手チームの<<ディフェンスエリア/Defense Area, ディフェンスエリア>>にある間、ボールに接触してはならない。 +
-The ball must not be touched while being partially or fully inside the opponent <<ディフェンスエリア/Defense Area, defense area>>.
+The ball must not be touched by a robot, while the robot is partially or fully inside the opponent <<ディフェンスエリア/Defense Area, defense area>>.
 
 ===== ボール速度/Ball Speed
 ロボットは3D空間内で6.5m/s以上の速さでボールをシュートしてはならない。 +

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -159,7 +159,7 @@ robots' positions, ball speed or any other property that is causing
 the violation before being penalized additional times.
 
 ===== 相手ディフェンスエリア内でのアタッカーのボールへの接触/Attacker Touched Ball In Opponent Defense Area
-ボールが部分的にもしくは完全に相手チームの<<ディフェンスエリア/Defense Area, ディフェンスエリア>>にある間、ボールに接触してはならない。 +
+ロボットが部分的にもしくは完全に相手チームの<<ディフェンスエリア/Defense Area, ディフェンスエリア>>にある間、そのロボットはボールに接触してはならない。 +
 The ball must not be touched by a robot, while the robot is partially or fully inside the opponent <<ディフェンスエリア/Defense Area, defense area>>.
 
 ===== ボール速度/Ball Speed


### PR DESCRIPTION
[本家Pull Request 41](https://github.com/robocup-ssl/ssl-rules/pull/41)の作業です。  


- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review

本MRにより、ルール「[相手ディフェンスエリア内でのアタッカーのボールへの接触](https://github.com/kkimurak/ssl-rules-ja/blob/f4f5578efe606f08df305be48a06437cb107c643/chapters/offenses.adoc#相手ディフェンスエリア内でのアタッカーのボールへの接触attacker-touched-ball-in-opponent-defense-area)」において誤訳が修正されます。  
