### PR TITLE
Upstream/47 PDFビルド時の分岐設定修正

### DIFF
--- a/sslrules.adoc
+++ b/sslrules.adoc
@@ -7,11 +7,11 @@ include::https://raw.githubusercontent.com/asciidoctor/asciidoctor/master/data/l
 :toclevels: 4
 
 // add icons from fontawesome in a up-to-date version
-ifdef::basebackend-html[]
+ifdef::backend-html5[]
 ++++
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
 ++++
-endif::basebackend-html[]
+endif::backend-html5[]
 
 :icons: font
 :numbered:


### PR DESCRIPTION
[本家Pull Request 47](https://github.com/robocup-ssl/ssl-rules/pull/41)の作業です。原コミッターも私なので逆輸入になります。  

- [x] cherry-pick
- [x] resolve conflict
- [ ] translation
- [ ] review

本MRにより、PDFをビルドした際にWeb版用のCSSリンクが意図せず表示されてしまう不具合が修正されます。
